### PR TITLE
Fix Signal dashboard channel health

### DIFF
--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -20,6 +20,7 @@ import Database from 'better-sqlite3';
 
 import { STORE_DIR, SESSIONS_DIR } from '../config.js';
 import { logger } from '../logger.js';
+import { buildChannelStatus } from '../channel-status.js';
 import { NanoCrabState, setState, getState } from './state.js';
 import { initAuth } from './auth.js';
 import { requireAuth, requireRole } from './middleware.js';
@@ -191,10 +192,7 @@ export async function initAdminServer(state: NanoCrabState): Promise<void> {
   // Public health endpoint (no auth required)
   app.get('/health', (_req, res) => {
     const state = getState();
-    const channels = state.channels.map((ch) => ({
-      name: ch.name,
-      connected: ch.isConnected(),
-    }));
+    const channels = state.channels.map((ch) => buildChannelStatus(ch));
     const allUp = channels.every((c) => c.connected);
     res.status(allUp ? 200 : 503).json({
       status: allUp ? 'healthy' : 'degraded',

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -54,7 +54,7 @@ const groups = [
     name: 'Scouting Desk',
     folder: 'scouts',
     channel: 'signal',
-    enabled: false,
+    enabled: true,
     active: false,
     isMain: true,
     isPrimary: false,
@@ -70,7 +70,14 @@ const groups = [
 const channels = [
   { name: 'whatsapp', connected: true, status: 'healthy', lastSeen: iso(1) },
   { name: 'telegram', connected: true, status: 'healthy', lastSeen: iso(3) },
-  { name: 'signal', connected: true, status: 'healthy', lastSeen: iso(1) },
+  {
+    name: 'signal',
+    connected: true,
+    status: 'healthy',
+    lastSeen: iso(1),
+    lastActiveAt: iso(1),
+    statusReason: 'Mock Signal message activity observed',
+  },
 ];
 
 const agentBoundaries = [
@@ -1722,8 +1729,23 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
           icon: 'SG',
           description: 'Scout desk and private alerts.',
           connected: true,
+          status: 'healthy',
+          lastActiveAt: iso(1),
+          statusReason: 'Mock Signal message activity observed',
           envVars: ['SIGNAL_PHONE_NUMBER'],
           config: { SIGNAL_PHONE_NUMBER: '+47 *** ** 107' },
+        },
+        {
+          id: 'signal-failing',
+          name: 'Signal (failing sample)',
+          icon: 'SG',
+          description: 'Mock diagnostic sample for a Signal daemon failure.',
+          connected: false,
+          status: 'down',
+          lastActiveAt: iso(180),
+          statusReason: 'Mock signal-cli daemon is not connected',
+          envVars: ['SIGNAL_PHONE_NUMBER'],
+          config: { SIGNAL_PHONE_NUMBER: '+47 *** ** 108' },
         },
       ],
       available: [

--- a/src/admin/public/pages/agents.js
+++ b/src/admin/public/pages/agents.js
@@ -56,6 +56,7 @@ async function renderAgents(el) {
       researchJobs,
       terminals,
       boundaries,
+      channelInfo,
     ] = await Promise.all([
       api('/groups').catch(() => []),
       api('/containers').catch(() => []),
@@ -73,8 +74,16 @@ async function renderAgents(el) {
       api('/research/jobs').catch(() => []),
       api('/sessions/terminal/active').catch(() => []),
       api('/agents/boundaries').catch(() => []),
+      api('/channels').catch(() => ({ active: [] })),
     ]);
     const groups = Array.isArray(groupsRaw) ? groupsRaw : [];
+    const channels = Array.isArray(channelInfo?.active)
+      ? channelInfo.active
+      : [];
+    const channelById = channels.reduce((acc, channel) => {
+      if (channel.id) acc[channel.id] = channel;
+      return acc;
+    }, {});
     const boundaryByFolder = (boundaries || []).reduce((acc, item) => {
       if (item.folder) acc[item.folder] = item;
       return acc;
@@ -92,6 +101,8 @@ async function renderAgents(el) {
         const container = containers.find(
           (c) => c.groupJid === g.jid || c.groupFolder === g.folder,
         );
+        const channelStatus = channelById[ch];
+        const channelConnected = channelStatus?.connected === true;
         const isActive = !!container;
         const isIdle = container?.idleWaiting;
         const isEnabled = g.enabled !== false;
@@ -110,26 +121,36 @@ async function renderAgents(el) {
         if (!isEnabled) {
           statusBadge = 'Disabled';
           statusColor = 'badge-muted';
+        } else if (!channelStatus || !channelConnected) {
+          statusBadge = 'Offline';
+          statusColor = 'badge-error';
         } else if (isActive && !isIdle) {
           statusBadge = 'Running';
           statusColor = 'badge-success';
         } else if (isActive && isIdle) {
           statusBadge = 'Idle';
           statusColor = 'badge-warning';
+        } else if (channelConnected) {
+          statusBadge = 'Active';
+          statusColor = 'badge-success';
         } else {
           statusBadge = 'Offline';
           statusColor = 'badge-error';
         }
 
+        const lastActive = g.lastActivity || channelStatus?.lastActiveAt;
+        const statusReason =
+          channelStatus?.statusReason || 'Channel adapter is not active';
+
         return `<div style="display:flex;justify-content:space-between;align-items:center;padding:10px 0;border-bottom:1px solid var(--border);${!isEnabled ? 'opacity:.62' : ''}">
         <div style="display:flex;align-items:center;gap:10px">
-          <span class="status-dot ${!isEnabled ? '' : isActive ? (isIdle ? 'idle' : 'online') : 'offline'}" style="width:8px;height:8px"></span>
+          <span class="status-dot ${!isEnabled ? '' : channelConnected ? (isActive && isIdle ? 'idle' : 'online') : 'offline'}" style="width:8px;height:8px"></span>
           <div>
             <strong>${esc(g.name)}</strong>
             <span class="badge badge-muted" style="margin-left:6px;font-size:9px">${ch}</span>
             ${g.isMain ? '<span class="badge badge-success" style="font-size:9px;margin-left:3px">Persistent</span>' : ''}
             ${isPrimary ? '<span class="badge badge-accent" style="font-size:9px;margin-left:3px">Primary</span>' : ''}
-            <div style="font-size:11px;color:var(--text-muted)">${g.lastActivity ? 'Active ' + timeAgo(g.lastActivity) : 'No activity'}</div>
+            <div style="font-size:11px;color:var(--text-muted)">${lastActive ? 'Active ' + timeAgo(lastActive) : 'No activity'} · ${esc(statusReason)}</div>
             <div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px">
               <span class="badge badge-muted" style="font-size:8px">${esc((boundary?.channelScopes || ['own']).join(','))} channels</span>
               <span class="badge ${boundary?.externalWrites?.allowed ? 'badge-warning' : 'badge-success'}" style="font-size:8px">${boundary?.externalWrites?.allowed ? 'writes gated' : 'read/write denied'}</span>

--- a/src/admin/routes/channels.ts
+++ b/src/admin/routes/channels.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { getState } from '../state.js';
 import { readEnvFile } from '../../env.js';
+import { buildChannelStatus } from '../../channel-status.js';
 
 const router = Router();
 
@@ -79,6 +80,7 @@ router.get('/', (_req: Request, res: Response) => {
   // Build active channels with status and config
   const activeChannels = state.channels.map((ch) => {
     const def = SUPPORTED_CHANNELS.find((s) => s.id === ch.name.toLowerCase());
+    const health = buildChannelStatus(ch);
     const config: Record<string, string> = {};
 
     if (def) {
@@ -116,7 +118,10 @@ router.get('/', (_req: Request, res: Response) => {
     return {
       name: ch.name,
       id: ch.name.toLowerCase(),
-      connected: ch.isConnected(),
+      connected: health.connected,
+      status: health.status,
+      lastActiveAt: health.lastActiveAt,
+      statusReason: health.reason,
       config,
       envVars: def?.envVars || [],
       description: def?.description || '',

--- a/src/admin/routes/system.ts
+++ b/src/admin/routes/system.ts
@@ -17,6 +17,7 @@ import {
 } from '../../config.js';
 import { readEnvFile, writeEnvValue } from '../../env.js';
 import { getState } from '../state.js';
+import { buildChannelStatus } from '../../channel-status.js';
 import { auditLog } from '../security.js';
 import { requireRole } from '../middleware.js';
 import { logger } from '../../logger.js';
@@ -160,10 +161,7 @@ router.get('/', (_req: Request, res: Response) => {
 router.get('/dashboard', async (_req: Request, res: Response) => {
   const state = getState();
   const uptimeMs = Date.now() - state.startTime;
-  const channels = state.channels.map((ch) => ({
-    name: ch.name,
-    connected: ch.isConnected(),
-  }));
+  const channels = state.channels.map((ch) => buildChannelStatus(ch));
   const containers = state.queue.getActiveContainers();
 
   const db = new Database(path.join(STORE_DIR, 'messages.db'), {
@@ -360,11 +358,7 @@ router.post(
 // Channel health check
 router.get('/health', (_req: Request, res: Response) => {
   const state = getState();
-  const health = state.channels.map((ch) => ({
-    name: ch.name,
-    connected: ch.isConnected(),
-    status: ch.isConnected() ? 'healthy' : 'down',
-  }));
+  const health = state.channels.map((ch) => buildChannelStatus(ch));
 
   const allHealthy = health.every((h) => h.connected);
   res.json({

--- a/src/admin/websocket.ts
+++ b/src/admin/websocket.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { logger } from '../logger.js';
+import { buildChannelStatus } from '../channel-status.js';
 import { getState } from './state.js';
 import { validateSession, getSessionUser, AdminUser } from './auth.js';
 import { SESSIONS_DIR, TERMINAL_IDLE_TIMEOUT_MS } from '../config.js';
@@ -239,10 +240,7 @@ function sendStatus(ws: WebSocket): void {
 function getStatusData(): object {
   const state = getState();
   return {
-    channels: state.channels.map((ch) => ({
-      name: ch.name,
-      connected: ch.isConnected(),
-    })),
+    channels: state.channels.map((ch) => buildChannelStatus(ch)),
     containers: state.queue.getActiveContainers(),
     uptime: Date.now() - state.startTime,
   };

--- a/src/channel-status.test.ts
+++ b/src/channel-status.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildChannelStatus } from './channel-status.js';
+import { Channel } from './types.js';
+
+function channel(overrides: Partial<Channel>): Channel {
+  return {
+    name: 'test',
+    connect: async () => {},
+    sendMessage: async () => {},
+    isConnected: () => false,
+    ownsJid: () => false,
+    disconnect: async () => {},
+    ...overrides,
+  };
+}
+
+describe('buildChannelStatus', () => {
+  it('uses default connected semantics when an adapter has no rich status', () => {
+    const status = buildChannelStatus(
+      channel({ name: 'telegram', isConnected: () => true }),
+    );
+
+    expect(status).toEqual({
+      name: 'telegram',
+      connected: true,
+      status: 'healthy',
+      lastActiveAt: null,
+      reason: 'telegram adapter reports connected',
+    });
+  });
+
+  it('preserves adapter-provided diagnostics and last activity', () => {
+    const status = buildChannelStatus(
+      channel({
+        name: 'signal',
+        isConnected: () => true,
+        getStatus: () => ({
+          name: 'signal',
+          connected: true,
+          status: 'healthy',
+          lastActiveAt: '2026-06-13T09:00:00.000Z',
+          reason: 'Signal message activity observed',
+        }),
+      }),
+    );
+
+    expect(status.status).toBe('healthy');
+    expect(status.connected).toBe(true);
+    expect(status.lastActiveAt).toBe('2026-06-13T09:00:00.000Z');
+    expect(status.reason).toBe('Signal message activity observed');
+  });
+});

--- a/src/channel-status.ts
+++ b/src/channel-status.ts
@@ -1,0 +1,31 @@
+import { Channel, ChannelStatusSnapshot } from './types.js';
+
+export function buildChannelStatus(channel: Channel): ChannelStatusSnapshot {
+  if (channel.getStatus) {
+    const status = channel.getStatus();
+    return {
+      name: status.name || channel.name,
+      connected: !!status.connected,
+      status:
+        status.status ||
+        (status.connected || channel.isConnected() ? 'healthy' : 'down'),
+      lastActiveAt: status.lastActiveAt || null,
+      reason: status.reason || defaultReason(status.connected, channel.name),
+    };
+  }
+
+  const connected = channel.isConnected();
+  return {
+    name: channel.name,
+    connected,
+    status: connected ? 'healthy' : 'down',
+    lastActiveAt: null,
+    reason: defaultReason(connected, channel.name),
+  };
+}
+
+function defaultReason(connected: boolean, channelName: string): string {
+  return connected
+    ? `${channelName} adapter reports connected`
+    : `${channelName} adapter reports disconnected`;
+}

--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -59,9 +59,26 @@ describe('SignalChannel connection status', () => {
     await channel.connect();
 
     expect(channel.isConnected()).toBe(true);
+    expect(channel.getStatus()).toMatchObject({
+      connected: true,
+      status: 'healthy',
+      reason: 'signal-cli RPC endpoint is ready',
+    });
+    expect(channel.getStatus().lastActiveAt).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/rpc'),
       expect.any(Object),
     );
+  });
+
+  it('reports a diagnostic reason after disconnect', async () => {
+    await channel.disconnect();
+
+    expect(channel.getStatus()).toMatchObject({
+      connected: false,
+      status: 'down',
+      lastActiveAt: null,
+      reason: 'Signal channel disconnected',
+    });
   });
 });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -17,7 +17,7 @@ import { logger } from '../logger.js';
 import { auditUploadSend } from '../upload-audit.js';
 import { transcribeAudio } from '../transcription.js';
 import { registerChannel, ChannelOpts } from './registry.js';
-import { Channel, NewMessage } from '../types.js';
+import { Channel, ChannelStatusSnapshot, NewMessage } from '../types.js';
 
 const SIGNAL_CLI_PORT = 8080;
 const DAEMON_STARTUP_TIMEOUT_MS = 90000;
@@ -74,6 +74,9 @@ export class SignalChannel implements Channel {
   private phoneNumber: string;
   private port: number;
   private connected = false;
+  private lastReadyAt: string | null = null;
+  private lastMessageAt: string | null = null;
+  private lastError: string | null = null;
   private daemonRestarts = 0;
   private rpcId = 0;
   private lastTimestamps = new Set<number>();
@@ -179,6 +182,8 @@ export class SignalChannel implements Channel {
         await this.rpc('version', {});
         logger.info('signal-cli daemon ready');
         this.connected = true;
+        this.lastReadyAt = new Date().toISOString();
+        this.lastError = null;
         this.daemonRestarts = 0;
         this.startMemoryWatchdog();
         return;
@@ -196,6 +201,7 @@ export class SignalChannel implements Channel {
     if (this.daemonRestarts >= MAX_DAEMON_RESTARTS) {
       logger.error('signal-cli daemon exceeded max restarts, giving up');
       this.connected = false;
+      this.lastError = 'signal-cli daemon exceeded max restarts';
       return;
     }
 
@@ -214,6 +220,7 @@ export class SignalChannel implements Channel {
     } catch (err) {
       logger.error({ err }, 'Failed to restart signal-cli daemon');
       this.connected = false;
+      this.lastError = err instanceof Error ? err.message : String(err);
     }
   }
 
@@ -260,6 +267,7 @@ export class SignalChannel implements Channel {
   }
 
   private async processMessage(msg: SignalJsonMessage): Promise<void> {
+    this.lastMessageAt = new Date().toISOString();
     const envelope = msg.envelope;
     const data = envelope.dataMessage;
     if (!data) return; // typing indicator, receipt, etc.
@@ -524,12 +532,28 @@ export class SignalChannel implements Channel {
     return this.connected;
   }
 
+  getStatus(): ChannelStatusSnapshot {
+    const lastActiveAt = maxIso(this.lastMessageAt, this.lastReadyAt);
+    return {
+      name: this.name,
+      connected: this.connected,
+      status: this.connected ? 'healthy' : 'down',
+      lastActiveAt,
+      reason: this.connected
+        ? lastActiveAt === this.lastMessageAt
+          ? 'Signal message activity observed'
+          : 'signal-cli RPC endpoint is ready'
+        : this.lastError || 'signal-cli daemon is not connected',
+    };
+  }
+
   ownsJid(jid: string): boolean {
     return jid.startsWith('sig:');
   }
 
   async disconnect(): Promise<void> {
     this.connected = false;
+    this.lastError = 'Signal channel disconnected';
 
     if (this.daemon) {
       this.daemon.kill('SIGTERM');
@@ -604,6 +628,12 @@ export class SignalChannel implements Channel {
     }
     return json.result;
   }
+}
+
+function maxIso(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return Date.parse(a) >= Date.parse(b) ? a : b;
 }
 
 function mimeToExt(mime: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,16 @@ export interface NewJournalEventRecord {
 
 // --- Channel abstraction ---
 
+export type ChannelHealthStatus = 'healthy' | 'down' | 'disabled' | 'degraded';
+
+export interface ChannelStatusSnapshot {
+  name: string;
+  connected: boolean;
+  status: ChannelHealthStatus;
+  lastActiveAt: string | null;
+  reason: string;
+}
+
 export interface Channel {
   name: string;
   connect(): Promise<void>;
@@ -229,6 +239,8 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: richer runtime health for dashboard and diagnostics.
+  getStatus?(): ChannelStatusSnapshot;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary
- Centralizes channel health snapshots for dashboard, health endpoint, websocket status, and channel settings.
- Adds Signal-specific health diagnostics with last-ready/message activity and offline reasons.
- Updates the Agents page so Bot Agents use channel health for Active/Offline status instead of treating no running container as offline.
- Adds mock data for both a healthy Signal channel and a failing Signal diagnostic sample.

Fixes #55.

## Verification
- PASS: `rtk mise exec node@22 -- npx vitest run src/channel-status.test.ts src/channels/signal.test.ts`
- PASS: `rtk mise exec node@22 -- npm run typecheck`
- PASS: `rtk mise exec node@22 -- npm run format:check`
- PASS: `rtk mise exec node@22 -- npm run build`
- PASS: `rtk mise exec node@22 -- npm test`
- PASS: mock admin API sanity check for healthy and failing Signal samples at `MOCK_ADMIN_PORT=5180 npm run mock:admin`

## Notes
Two unrelated untracked spec files remain local and are intentionally not part of this PR.