### PR TITLE
Add dashboard WhatsApp pairing

### DIFF
--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -1768,6 +1768,28 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       ],
     };
   }
+  if (pathname === '/channels/whatsapp/pairing') {
+    return {
+      state: 'waiting_for_qr_scan',
+      method: 'qr',
+      connected: false,
+      configured: false,
+      startedAt: iso(1),
+      qrCode:
+        'data:image/svg+xml;utf8,' +
+        encodeURIComponent(
+          '<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180"><rect width="180" height="180" fill="white"/><rect x="20" y="20" width="40" height="40" fill="black"/><rect x="120" y="20" width="40" height="40" fill="black"/><rect x="20" y="120" width="40" height="40" fill="black"/><rect x="80" y="80" width="20" height="20" fill="black"/><rect x="110" y="110" width="30" height="30" fill="black"/></svg>',
+        ),
+      qrExpiresAt: iso(-1),
+      qrExpired: false,
+      pairingCode: null,
+      error: null,
+      statusReason: 'Mock QR is waiting for a WhatsApp linked-device scan',
+    };
+  }
+  if (pathname.startsWith('/channels/whatsapp/pairing/')) {
+    return { ok: true, state: 'starting' };
+  }
   if (pathname === '/groups') return groups;
   if (pathname === '/containers') return containers;
   if (pathname === '/containers/recent') {

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -1821,7 +1821,10 @@ window.denyApproval = async function (id, groupJid) {
 
 // Channels
 async function renderChannels(el) {
-  const data = await api('/channels');
+  const [data, whatsappPairing] = await Promise.all([
+    api('/channels'),
+    api('/channels/whatsapp/pairing').catch(() => null),
+  ]);
 
   const activeHtml = data.active
     .map(
@@ -1840,6 +1843,7 @@ async function renderChannels(el) {
           <button class="btn btn-sm btn-ghost" onclick="restartChannel('${esc(ch.id)}',this)">Restart</button>
         </div>
       </div>
+      ${ch.id === 'whatsapp' ? renderWhatsAppPairingPanel(whatsappPairing) : ''}
       <table>
         ${ch.envVars
           .map(
@@ -1888,7 +1892,102 @@ async function renderChannels(el) {
     <div class="page-header"><h2>Channels</h2></div>
     <div class="grid grid-2">${activeHtml}</div>
     ${availableHtml}`;
+
+  if (whatsappPairing && currentPage === 'monitoring') {
+    poll(() => navigate('monitoring'), 5000);
+  }
 }
+
+function renderWhatsAppPairingPanel(pairing) {
+  if (!pairing) return '';
+  const stateLabel = pairing.state || 'unknown';
+  const stateBadge =
+    pairing.connected ||
+    pairing.state === 'paired' ||
+    pairing.state === 'connected'
+      ? 'badge-success'
+      : pairing.state === 'error' || pairing.state === 'expired_qr'
+        ? 'badge-error'
+        : pairing.state === 'not_configured'
+          ? 'badge-muted'
+          : 'badge-warning';
+  return `
+    <div style="margin:12px 0;padding:12px;background:var(--surface2);border-radius:var(--radius-sm);border:1px solid var(--border)">
+      <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
+        <div>
+          <div style="font-size:13px;font-weight:600">Dashboard Pairing</div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">${esc(pairing.statusReason || pairing.error || 'Use WhatsApp linked devices to pair this dashboard session.')}</div>
+        </div>
+        <span class="badge ${stateBadge}" style="font-size:10px">${esc(stateLabel)}</span>
+      </div>
+      ${
+        pairing.qrCode
+          ? `<div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
+              <img src="${pairing.qrCode}" alt="WhatsApp pairing QR code" style="width:180px;height:180px;background:#fff;padding:8px;border-radius:8px">
+              <div style="font-size:12px;color:var(--text-muted);max-width:260px">
+                <div style="font-weight:600;color:var(--text);margin-bottom:6px">Scan with WhatsApp</div>
+                <div>Settings -> Linked Devices -> Link a Device.</div>
+                <div style="margin-top:6px">Expires ${pairing.qrExpiresAt ? formatTime(pairing.qrExpiresAt) : 'soon'}.</div>
+              </div>
+            </div>`
+          : ''
+      }
+      ${
+        pairing.pairingCode
+          ? `<div style="font-size:22px;font-family:var(--mono);letter-spacing:2px;margin:8px 0;color:var(--accent)">${esc(pairing.pairingCode)}</div>`
+          : ''
+      }
+      ${
+        pairing.error
+          ? `<div class="alert-banner alert-error" style="margin:8px 0"><span>${esc(pairing.error)}</span></div>`
+          : ''
+      }
+      <div style="display:flex;gap:8px;flex-wrap:wrap">
+        <button class="btn btn-sm" onclick="startWhatsAppPairing('qr')">${pairing.qrExpired ? 'Refresh QR' : 'Start QR Pairing'}</button>
+        <button class="btn btn-sm btn-ghost" onclick="startWhatsAppPairing('pairing-code')">Pairing Code</button>
+        <button class="btn btn-sm btn-ghost" onclick="cancelWhatsAppPairing()">Cancel</button>
+        <button class="btn btn-sm btn-ghost" onclick="resetWhatsAppSession()">Reset Session</button>
+      </div>
+    </div>`;
+}
+
+window.startWhatsAppPairing = async function (method) {
+  let body = { method };
+  if (method === 'pairing-code') {
+    const phone = prompt('Phone number with country code, digits only');
+    if (!phone) return;
+    body.phone = phone;
+  }
+  const res = await api('/channels/whatsapp/pairing/start', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (res.ok) toast('WhatsApp pairing started', 'success');
+  else toast(res.error || 'Pairing failed to start', 'error');
+  navigate('monitoring');
+};
+
+window.cancelWhatsAppPairing = async function () {
+  const res = await api('/channels/whatsapp/pairing/cancel', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+  if (res.ok) toast('WhatsApp pairing cancelled', 'info');
+  else toast(res.error || 'Cancel failed', 'error');
+  navigate('monitoring');
+};
+
+window.resetWhatsAppSession = async function () {
+  if (!confirm('Reset WhatsApp session files and disconnect the channel?'))
+    return;
+  const res = await api('/channels/whatsapp/pairing/reset', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+  if (res.ok) toast('WhatsApp session reset', 'success');
+  else toast(res.error || 'Reset failed', 'error');
+  navigate('monitoring');
+};
 
 // Dashboard, agents, settings, coding, plugins, marketplace, and help.
 // are loaded from pages/*.js

--- a/src/admin/routes/channels.ts
+++ b/src/admin/routes/channels.ts
@@ -1,17 +1,161 @@
 import { Router, Request, Response } from 'express';
+import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import QRCode from 'qrcode';
 import { getState } from '../state.js';
 import { readEnvFile } from '../../env.js';
 import { buildChannelStatus } from '../../channel-status.js';
+import { requireRole } from '../middleware.js';
+import { logger } from '../../logger.js';
 
 const router = Router();
+const WHATSAPP_QR_TTL_MS = 60_000;
+
+let whatsappPairingProc: ChildProcess | null = null;
+let whatsappPairingStartedAt: string | null = null;
+let whatsappPairingError: string | null = null;
 
 /** Mask a sensitive value: show first 4 + ... + last 4 chars */
 function mask(value: string): string {
   if (!value) return '';
   if (value.length <= 12) return value.slice(0, 4) + '...';
   return value.slice(0, 4) + '...' + value.slice(-4);
+}
+
+function storePath(...parts: string[]): string {
+  return path.join(process.cwd(), 'store', ...parts);
+}
+
+function readTextSafe(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function whatsappCredentialsExist(): boolean {
+  return fs.existsSync(storePath('auth', 'creds.json'));
+}
+
+function readWhatsAppAuthStatus(): {
+  state: string;
+  error: string | null;
+  pairingCode: string | null;
+} {
+  if (whatsappCredentialsExist()) {
+    return { state: 'paired', error: null, pairingCode: null };
+  }
+
+  const content = readTextSafe(storePath('auth-status.txt'));
+  const pairingCode = readTextSafe(storePath('pairing-code.txt')) || null;
+  if (!content) {
+    return {
+      state: whatsappPairingProc ? 'starting' : 'not_configured',
+      error: whatsappPairingError,
+      pairingCode,
+    };
+  }
+  if (content === 'authenticated' || content === 'already_authenticated') {
+    return { state: 'paired', error: null, pairingCode };
+  }
+  if (content.startsWith('pairing_code:')) {
+    return {
+      state: 'waiting_for_pairing_code',
+      error: null,
+      pairingCode: content.replace('pairing_code:', '') || pairingCode,
+    };
+  }
+  if (content.startsWith('failed:')) {
+    return {
+      state: 'error',
+      error: content.replace('failed:', '') || 'unknown',
+      pairingCode,
+    };
+  }
+  return { state: content, error: whatsappPairingError, pairingCode };
+}
+
+async function readWhatsAppQr(): Promise<{
+  qrCode: string | null;
+  qrExpiresAt: string | null;
+  qrExpired: boolean;
+}> {
+  const qrPath = storePath('qr-data.txt');
+  if (!fs.existsSync(qrPath)) {
+    return { qrCode: null, qrExpiresAt: null, qrExpired: false };
+  }
+  const stat = fs.statSync(qrPath);
+  const qrExpiresAt = new Date(stat.mtimeMs + WHATSAPP_QR_TTL_MS).toISOString();
+  const qrExpired = Date.now() > stat.mtimeMs + WHATSAPP_QR_TTL_MS;
+  const qrData = readTextSafe(qrPath);
+  if (!qrData || qrExpired) {
+    return { qrCode: null, qrExpiresAt, qrExpired };
+  }
+  return {
+    qrCode: await QRCode.toDataURL(qrData, { margin: 1, width: 280 }),
+    qrExpiresAt,
+    qrExpired,
+  };
+}
+
+function stopWhatsAppPairingProcess(): void {
+  if (!whatsappPairingProc) return;
+  try {
+    whatsappPairingProc.kill('SIGTERM');
+  } catch {
+    // Process may have already exited.
+  }
+  whatsappPairingProc = null;
+}
+
+function startWhatsAppPairing(method: string, phone?: string): void {
+  stopWhatsAppPairingProcess();
+  whatsappPairingError = null;
+  whatsappPairingStartedAt = new Date().toISOString();
+
+  fs.mkdirSync(storePath(), { recursive: true });
+  for (const file of ['qr-data.txt', 'auth-status.txt', 'pairing-code.txt']) {
+    try {
+      fs.unlinkSync(storePath(file));
+    } catch {
+      // Missing stale state is fine.
+    }
+  }
+
+  const args =
+    method === 'pairing-code'
+      ? [
+          'tsx',
+          'src/whatsapp-auth.ts',
+          '--pairing-code',
+          '--phone',
+          phone || '',
+        ]
+      : ['tsx', 'src/whatsapp-auth.ts'];
+  whatsappPairingProc = spawn('npx', args, {
+    cwd: process.cwd(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const logFile = path.join(process.cwd(), 'logs', 'whatsapp-pairing.log');
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+  whatsappPairingProc.stdout?.pipe(logStream);
+  whatsappPairingProc.stderr?.pipe(logStream);
+
+  whatsappPairingProc.on('error', (err) => {
+    whatsappPairingError = err.message;
+    logger.error({ err }, 'WhatsApp dashboard pairing failed to start');
+  });
+  whatsappPairingProc.on('exit', (code) => {
+    if (code && code !== 0) {
+      whatsappPairingError ||= `auth process exited with code ${code}`;
+    }
+    whatsappPairingProc = null;
+    logStream.end();
+  });
 }
 
 /** All supported channels with their env requirements */
@@ -148,5 +292,89 @@ router.get('/', (_req: Request, res: Response) => {
 
   res.json({ active: activeChannels, available: availableChannels });
 });
+
+router.get('/whatsapp/pairing', async (_req: Request, res: Response) => {
+  const auth = readWhatsAppAuthStatus();
+  const qr = await readWhatsAppQr();
+  const whatsappChannel = getState().channels.find(
+    (ch) => ch.name.toLowerCase() === 'whatsapp',
+  );
+  const health = whatsappChannel ? buildChannelStatus(whatsappChannel) : null;
+
+  const state =
+    health?.connected === true
+      ? 'connected'
+      : qr.qrCode
+        ? 'waiting_for_qr_scan'
+        : qr.qrExpired
+          ? 'expired_qr'
+          : auth.state;
+
+  res.json({
+    state,
+    method: readTextSafe(storePath('pairing-code.txt')) ? 'pairing-code' : 'qr',
+    connected: health?.connected === true,
+    configured: whatsappCredentialsExist(),
+    startedAt: whatsappPairingStartedAt,
+    qrCode: qr.qrCode,
+    qrExpiresAt: qr.qrExpiresAt,
+    qrExpired: qr.qrExpired,
+    pairingCode: auth.pairingCode,
+    error: auth.error || whatsappPairingError,
+    statusReason: health?.reason || null,
+  });
+});
+
+router.post(
+  '/whatsapp/pairing/start',
+  requireRole('owner'),
+  (req: Request, res: Response) => {
+    const method = req.body?.method === 'pairing-code' ? 'pairing-code' : 'qr';
+    const phone = String(req.body?.phone || '').replace(/\D/g, '');
+    if (method === 'pairing-code' && !phone) {
+      res.status(400).json({ error: 'phone is required for pairing-code' });
+      return;
+    }
+    startWhatsAppPairing(method, phone);
+    res.json({ ok: true, state: 'starting' });
+  },
+);
+
+router.post(
+  '/whatsapp/pairing/cancel',
+  requireRole('owner'),
+  (_req: Request, res: Response) => {
+    stopWhatsAppPairingProcess();
+    whatsappPairingError = null;
+    res.json({ ok: true, state: 'cancelled' });
+  },
+);
+
+router.post(
+  '/whatsapp/pairing/reset',
+  requireRole('owner'),
+  async (_req: Request, res: Response) => {
+    stopWhatsAppPairingProcess();
+    const whatsappChannel = getState().channels.find(
+      (ch) => ch.name.toLowerCase() === 'whatsapp',
+    );
+    try {
+      await whatsappChannel?.disconnect();
+    } catch (err) {
+      logger.warn({ err }, 'Failed to disconnect WhatsApp before reset');
+    }
+    fs.rmSync(storePath('auth'), { recursive: true, force: true });
+    for (const file of ['qr-data.txt', 'auth-status.txt', 'pairing-code.txt']) {
+      try {
+        fs.unlinkSync(storePath(file));
+      } catch {
+        // Missing stale state is fine.
+      }
+    }
+    whatsappPairingError = null;
+    whatsappPairingStartedAt = null;
+    res.json({ ok: true, state: 'not_configured' });
+  },
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- Adds authenticated dashboard WhatsApp pairing status and owner-only start/cancel/reset controls.
- Streams the current QR into the Channels page as a server-generated data URL while keeping `store/auth` session files private.
- Reuses the existing `src/whatsapp-auth.ts` terminal-compatible auth flow so SSH/headless recovery remains available.
- Adds QR expiry/error/pairing-code state and mock dashboard pairing samples.

Fixes #56.

## Verification
- PASS: `rtk mise exec node@22 -- npm run typecheck`
- PASS: `rtk mise exec node@22 -- npm run format:check`
- PASS: `rtk mise exec node@22 -- npm run build`
- PASS: `rtk mise exec node@22 -- npx vitest run src/channel-status.test.ts src/channels/whatsapp.test.ts`
- PASS: `rtk node --check src/admin/public/app.js`
- PASS: `rtk mise exec node@22 -- npm test`
- PASS: mock admin API sanity check for pairing QR payload and controls

## Security Notes
- The browser API exposes QR image/state/error only, not WhatsApp credential/session files.
- Mutating pairing controls require owner role on top of the existing authenticated dashboard mount.
- Reset removes only WhatsApp auth/status artifacts and attempts to disconnect the WhatsApp channel first.