### PR TITLE
Add production release diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,13 @@ state is persisted in `.setup-state.json` with `pending`, `running`,
 `completed`, and `failed` statuses so reruns resume at the failed or next
 incomplete step.
 
+Owners can also use **Settings -> Production Release Diagnostics** before a
+deployment. The checklist combines first-run preflight results with release
+gates for a clean Git worktree, compiled server/admin output, operator docs,
+runtime state, backups, and service supervision. Required failures block the
+release status; advisory failures flag operational work to finish before going
+live.
+
 Setup logs are written to `logs/setup.log`; credential-looking material is
 redacted before it is logged. For a disposable VPS rehearsal, see
 [docs/FIRST_RUN_VPS_TEST.md](docs/FIRST_RUN_VPS_TEST.md).

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -1649,6 +1649,91 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       ],
     };
   }
+  if (pathname === '/system/release-diagnostics') {
+    return {
+      status: 'attention',
+      generatedAt: iso(0),
+      summary: { total: 8, passed: 7, failedRequired: 0, failedAdvisory: 1 },
+      sections: [
+        {
+          id: 'setup',
+          title: 'Install Readiness',
+          checks: [
+            {
+              id: 'setup-node',
+              label: 'Node.js',
+              ok: true,
+              severity: 'required',
+              detail: 'Node 22.x detected',
+            },
+            {
+              id: 'setup-container-runtime',
+              label: 'Container runtime',
+              ok: true,
+              severity: 'required',
+              detail: 'Docker is available',
+            },
+          ],
+        },
+        {
+          id: 'release',
+          title: 'Release Gate',
+          checks: [
+            {
+              id: 'git-clean',
+              label: 'Git worktree',
+              ok: true,
+              severity: 'required',
+              detail: 'No uncommitted or untracked files',
+            },
+            {
+              id: 'compiled-output',
+              label: 'Compiled server output',
+              ok: true,
+              severity: 'required',
+              detail: 'dist/index.js exists',
+            },
+            {
+              id: 'admin-assets',
+              label: 'Compiled admin assets',
+              ok: true,
+              severity: 'required',
+              detail: 'Admin assets are present in dist/admin/public',
+            },
+          ],
+        },
+        {
+          id: 'operations',
+          title: 'Operations Safety',
+          checks: [
+            {
+              id: 'runtime-state',
+              label: 'Runtime state detected',
+              ok: true,
+              severity: 'advisory',
+              detail: 'Sample channels and groups have runtime state',
+            },
+            {
+              id: 'backup-plan',
+              label: 'Backup plan',
+              ok: false,
+              severity: 'advisory',
+              detail:
+                'No mock backup archive or auto-backup configuration found',
+              hint: 'Create a backup or configure automatic backups before production release',
+            },
+            {
+              id: 'service-manager',
+              label: 'Service manager',
+              ok: true,
+              severity: 'advisory',
+              detail: 'systemctl is available in the release target',
+            },
+          ],
+        },
+      ],
+    };
+  }
   if (pathname === '/system') return system();
   if (pathname === '/system/stats') {
     return {

--- a/src/admin/public/pages/settings.js
+++ b/src/admin/public/pages/settings.js
@@ -38,9 +38,13 @@ async function renderSettings(el) {
   } catch {}
   const isOwner = (window._userRole || 'owner') === 'owner';
   let setupPreflight = null;
+  let releaseDiagnostics = null;
   if (isOwner) {
     try {
       setupPreflight = await api('/system/setup/preflight');
+    } catch {}
+    try {
+      releaseDiagnostics = await api('/system/release-diagnostics');
     } catch {}
   }
   const providerModels = providerInfo.models || {
@@ -326,6 +330,23 @@ async function renderSettings(el) {
       </div>
     </div>`
       : '';
+  const releaseDiagnosticsCard =
+    isOwner && releaseDiagnostics
+      ? `
+    <div class="card" style="margin-bottom:16px">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:10px">
+        <div>
+          <div class="card-title" style="margin:0">Production Release Diagnostics</div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">Required gates must pass before production release; advisory gates flag operational risk.</div>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center">
+          <span class="badge ${releaseDiagnostics.status === 'ready' ? 'badge-success' : releaseDiagnostics.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(releaseDiagnostics.status)}</span>
+          <button class="btn btn-sm btn-ghost" onclick="refreshReleaseDiagnostics()">Refresh</button>
+        </div>
+      </div>
+      <div id="release-diagnostics-list">${renderReleaseDiagnostics(releaseDiagnostics)}</div>
+    </div>`
+      : '';
 
   el.innerHTML = `
     <div class="page-header"><h2>Settings</h2></div>
@@ -384,6 +405,7 @@ async function renderSettings(el) {
     ${providerProfilesCard}`
         : ''
     }
+    ${releaseDiagnosticsCard}
     ${setupPreflightCard}
     ${isOwner ? '<div id="users-section"></div>' : ''}
     ${isOwner ? agentBoundaryCard : ''}
@@ -622,6 +644,32 @@ async function renderSettings(el) {
     };
 }
 
+function renderReleaseDiagnostics(result) {
+  return (result.sections || [])
+    .map(
+      (section) => `
+      <div style="margin-top:12px">
+        <div style="font-size:12px;font-weight:700;color:var(--text);margin-bottom:6px">${esc(section.title)}</div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:8px">
+          ${(section.checks || [])
+            .map(
+              (check) => `
+              <div style="padding:9px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+                <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+                  <strong style="font-size:12px;color:var(--text)">${esc(check.label)}</strong>
+                  <span class="badge ${check.ok ? 'badge-success' : check.severity === 'required' ? 'badge-error' : 'badge-warning'}">${check.ok ? 'OK' : check.severity === 'required' ? 'Block' : 'Warn'}</span>
+                </div>
+                <div style="font-size:11px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(check.detail || '')}</div>
+                ${check.hint && !check.ok ? `<div style="font-size:11px;color:var(--warning);margin-top:5px;line-height:1.35">${esc(check.hint)}</div>` : ''}
+              </div>`,
+            )
+            .join('')}
+        </div>
+      </div>`,
+    )
+    .join('');
+}
+
 // --- User Management ---
 async function loadUsersSection() {
   const section = document.getElementById('users-section');
@@ -767,7 +815,8 @@ window.preflightProvider = async function (provider) {
 window.refreshSetupPreflight = async function () {
   const target = document.getElementById('setup-preflight-list');
   if (!target) return;
-  target.innerHTML = '<div style="font-size:12px;color:var(--text-muted)">Checking...</div>';
+  target.innerHTML =
+    '<div style="font-size:12px;color:var(--text-muted)">Checking...</div>';
   try {
     const result = await api('/system/setup/preflight');
     target.innerHTML = result.checks
@@ -782,6 +831,19 @@ window.refreshSetupPreflight = async function () {
         </div>`,
       )
       .join('');
+  } catch (e) {
+    target.innerHTML = `<span class="badge badge-error">Fail</span> ${esc(e.message)}`;
+  }
+};
+
+window.refreshReleaseDiagnostics = async function () {
+  const target = document.getElementById('release-diagnostics-list');
+  if (!target) return;
+  target.innerHTML =
+    '<div style="font-size:12px;color:var(--text-muted)">Checking...</div>';
+  try {
+    const result = await api('/system/release-diagnostics');
+    target.innerHTML = renderReleaseDiagnostics(result);
   } catch (e) {
     target.innerHTML = `<span class="badge badge-error">Fail</span> ${esc(e.message)}`;
   }

--- a/src/admin/routes/system.ts
+++ b/src/admin/routes/system.ts
@@ -29,6 +29,7 @@ import {
 } from '../../edition.js';
 import { ensureCodexOAuth, getCodexAuthStatus } from '../../codex-auth.js';
 import { runSetupPreflight } from '../../setup-preflight.js';
+import { runReleaseDiagnostics } from '../../release-diagnostics.js';
 import { CONTAINER_RUNTIME_BIN } from '../../container-runtime.js';
 import {
   AGENT_PROVIDER_DEFINITIONS,
@@ -388,6 +389,15 @@ router.get('/setup/preflight', requireRole('owner'), async (_req, res) => {
       ok: false,
       error: err instanceof Error ? err.message : String(err),
     });
+  }
+});
+
+router.get('/release-diagnostics', requireRole('owner'), async (_req, res) => {
+  try {
+    res.json(await runReleaseDiagnostics());
+  } catch (err) {
+    logger.error({ err }, 'Release diagnostics failed');
+    res.status(500).json({ error: 'Release diagnostics failed' });
   }
 });
 

--- a/src/release-diagnostics.test.ts
+++ b/src/release-diagnostics.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { runReleaseDiagnostics } from './release-diagnostics.js';
+
+function makeProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-release-'));
+  fs.mkdirSync(path.join(root, 'dist', 'admin', 'public'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'store'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'dist', 'index.js'), '');
+  fs.writeFileSync(path.join(root, 'dist', 'admin', 'public', 'app.js'), '');
+  fs.writeFileSync(path.join(root, 'docs', 'DEBUG_CHECKLIST.md'), '');
+  fs.writeFileSync(path.join(root, 'docs', 'FIRST_RUN_VPS_TEST.md'), '');
+  fs.writeFileSync(path.join(root, 'docs', 'SECURITY.md'), '');
+  fs.writeFileSync(path.join(root, 'store', 'backup-auto.json'), '{}');
+  fs.writeFileSync(path.join(root, 'groups', 'main.json'), '{}');
+  return root;
+}
+
+const passingPreflight = {
+  ok: true,
+  checks: [
+    {
+      id: 'node',
+      label: 'Node.js',
+      ok: true,
+      severity: 'required' as const,
+      detail: 'Node 22.x detected',
+    },
+  ],
+};
+
+describe('release diagnostics', () => {
+  it('reports ready when required release gates pass', async () => {
+    const root = makeProject();
+    const result = await runReleaseDiagnostics({
+      projectRoot: root,
+      storeDir: path.join(root, 'store'),
+      dataDir: path.join(root, 'data'),
+      groupsDir: path.join(root, 'groups'),
+      setupPreflight: passingPreflight,
+      commandExists: () => true,
+      runCommand: () => ({ ok: true, detail: '' }),
+    });
+
+    expect(result.summary.failedRequired).toBe(0);
+    expect(result.status).toBe('ready');
+    expect(result.sections.find((s) => s.id === 'release')?.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'git-clean', ok: true }),
+        expect.objectContaining({ id: 'compiled-output', ok: true }),
+      ]),
+    );
+  });
+
+  it('blocks release on dirty worktree without exposing secret-like values', async () => {
+    const root = makeProject();
+    const result = await runReleaseDiagnostics({
+      projectRoot: root,
+      storeDir: path.join(root, 'store'),
+      dataDir: path.join(root, 'data'),
+      groupsDir: path.join(root, 'groups'),
+      setupPreflight: passingPreflight,
+      commandExists: () => true,
+      runCommand: () => ({
+        ok: true,
+        detail: ' M .env\n?? token=super-secret-value\n',
+      }),
+    });
+
+    expect(result.status).toBe('blocked');
+    const allText = JSON.stringify(result);
+    expect(allText).not.toContain('super-secret-value');
+    expect(allText).not.toContain('token=');
+    expect(
+      result.sections.find((s) => s.id === 'release')?.checks,
+    ).toContainEqual(
+      expect.objectContaining({
+        id: 'git-clean',
+        ok: false,
+        severity: 'required',
+      }),
+    );
+  });
+});

--- a/src/release-diagnostics.ts
+++ b/src/release-diagnostics.ts
@@ -1,0 +1,266 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR, GROUPS_DIR, STORE_DIR } from './config.js';
+import {
+  runSetupPreflight,
+  SetupPreflightCheck,
+  SetupPreflightResult,
+} from './setup-preflight.js';
+
+export type ReleaseDiagnosticSeverity = 'required' | 'advisory';
+export type ReleaseDiagnosticStatus = 'ready' | 'blocked' | 'attention';
+
+export interface ReleaseDiagnosticCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  severity: ReleaseDiagnosticSeverity;
+  detail: string;
+  hint?: string;
+}
+
+export interface ReleaseDiagnosticSection {
+  id: string;
+  title: string;
+  checks: ReleaseDiagnosticCheck[];
+}
+
+export interface ReleaseDiagnosticsResult {
+  status: ReleaseDiagnosticStatus;
+  generatedAt: string;
+  summary: {
+    total: number;
+    passed: number;
+    failedRequired: number;
+    failedAdvisory: number;
+  };
+  sections: ReleaseDiagnosticSection[];
+}
+
+export interface ReleaseDiagnosticsOptions {
+  projectRoot?: string;
+  storeDir?: string;
+  dataDir?: string;
+  groupsDir?: string;
+  runCommand?: (
+    command: string,
+    args: string[],
+  ) => { ok: boolean; detail: string };
+  commandExists?: (command: string) => boolean;
+  setupPreflight?: SetupPreflightResult;
+}
+
+function defaultRunCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+): { ok: boolean; detail: string } {
+  try {
+    return {
+      ok: true,
+      detail: execFileSync(command, args, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 10000,
+      }).trim(),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function defaultCommandExists(command: string): boolean {
+  try {
+    execFileSync('which', [command], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fileExists(projectRoot: string, relativePath: string): boolean {
+  return fs.existsSync(path.join(projectRoot, relativePath));
+}
+
+function directoryHasEntries(directory: string): boolean {
+  try {
+    return fs.existsSync(directory) && fs.readdirSync(directory).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function summarize(sections: ReleaseDiagnosticSection[]) {
+  const checks = sections.flatMap((section) => section.checks);
+  const failedRequired = checks.filter(
+    (check) => !check.ok && check.severity === 'required',
+  ).length;
+  const failedAdvisory = checks.filter(
+    (check) => !check.ok && check.severity === 'advisory',
+  ).length;
+  return {
+    total: checks.length,
+    passed: checks.filter((check) => check.ok).length,
+    failedRequired,
+    failedAdvisory,
+  };
+}
+
+function preflightChecks(
+  checks: SetupPreflightCheck[],
+): ReleaseDiagnosticCheck[] {
+  return checks.map((check) => ({
+    id: `setup-${check.id}`,
+    label: check.label,
+    ok: check.ok,
+    severity: check.severity,
+    detail: check.detail,
+    hint: check.hint,
+  }));
+}
+
+export async function runReleaseDiagnostics(
+  options: ReleaseDiagnosticsOptions = {},
+): Promise<ReleaseDiagnosticsResult> {
+  const projectRoot = options.projectRoot || process.cwd();
+  const storeDir = options.storeDir || STORE_DIR;
+  const dataDir = options.dataDir || DATA_DIR;
+  const groupsDir = options.groupsDir || GROUPS_DIR;
+  const runCommand =
+    options.runCommand ||
+    ((command, args) => defaultRunCommand(command, args, projectRoot));
+  const commandExists = options.commandExists || defaultCommandExists;
+  const setup =
+    options.setupPreflight ||
+    (await runSetupPreflight({
+      projectRoot,
+      dryRun: true,
+      commandExists,
+      runCommand,
+    }));
+
+  const gitStatus = runCommand('git', ['status', '--porcelain']);
+  const backupAutoConfig = path.join(storeDir, 'backup-auto.json');
+  const backupsDir = path.join(projectRoot, 'backups');
+  const hasRuntimeState =
+    directoryHasEntries(storeDir) ||
+    directoryHasEntries(dataDir) ||
+    directoryHasEntries(groupsDir);
+
+  const sections: ReleaseDiagnosticSection[] = [
+    {
+      id: 'setup',
+      title: 'Install Readiness',
+      checks: preflightChecks(setup.checks),
+    },
+    {
+      id: 'release',
+      title: 'Release Gate',
+      checks: [
+        {
+          id: 'git-clean',
+          label: 'Git worktree',
+          ok: gitStatus.ok && gitStatus.detail.trim().length === 0,
+          severity: 'required',
+          detail:
+            gitStatus.ok && gitStatus.detail.trim().length === 0
+              ? 'No uncommitted or untracked files'
+              : 'Worktree has uncommitted or untracked files',
+          hint: 'Commit, stash, or intentionally ignore local files before release',
+        },
+        {
+          id: 'compiled-output',
+          label: 'Compiled server output',
+          ok: fileExists(projectRoot, 'dist/index.js'),
+          severity: 'required',
+          detail: fileExists(projectRoot, 'dist/index.js')
+            ? 'dist/index.js exists'
+            : 'dist/index.js is missing',
+          hint: 'Run npm run build before release',
+        },
+        {
+          id: 'admin-assets',
+          label: 'Compiled admin assets',
+          ok: fileExists(projectRoot, 'dist/admin/public/app.js'),
+          severity: 'required',
+          detail: fileExists(projectRoot, 'dist/admin/public/app.js')
+            ? 'Admin assets are present in dist/admin/public'
+            : 'Admin assets are missing from dist/admin/public',
+          hint: 'Run npm run build before release',
+        },
+        {
+          id: 'release-docs',
+          label: 'Operator docs',
+          ok:
+            fileExists(projectRoot, 'docs/DEBUG_CHECKLIST.md') &&
+            fileExists(projectRoot, 'docs/FIRST_RUN_VPS_TEST.md') &&
+            fileExists(projectRoot, 'docs/SECURITY.md'),
+          severity: 'advisory',
+          detail:
+            'Debug checklist, VPS rehearsal notes, and security model docs should be present',
+          hint: 'Refresh operator docs when release behavior changes',
+        },
+      ],
+    },
+    {
+      id: 'operations',
+      title: 'Operations Safety',
+      checks: [
+        {
+          id: 'runtime-state',
+          label: 'Runtime state detected',
+          ok: hasRuntimeState,
+          severity: 'advisory',
+          detail: hasRuntimeState
+            ? 'Runtime store/data/groups directories contain state'
+            : 'No runtime state detected yet',
+          hint: 'Run setup and at least one channel/provider flow before production use',
+        },
+        {
+          id: 'backup-plan',
+          label: 'Backup plan',
+          ok:
+            fs.existsSync(backupAutoConfig) || directoryHasEntries(backupsDir),
+          severity: 'advisory',
+          detail: fs.existsSync(backupAutoConfig)
+            ? 'Auto-backup configuration exists'
+            : directoryHasEntries(backupsDir)
+              ? 'At least one backup archive exists'
+              : 'No backup archive or auto-backup configuration found',
+          hint: 'Create a backup or configure automatic backups before production release',
+        },
+        {
+          id: 'service-manager',
+          label: 'Service manager',
+          ok: commandExists('systemctl') || process.platform === 'darwin',
+          severity: 'advisory',
+          detail: commandExists('systemctl')
+            ? 'systemctl is available'
+            : process.platform === 'darwin'
+              ? 'macOS development environment detected'
+              : 'systemctl is not available',
+          hint: 'Use a supervised service such as systemd for production',
+        },
+      ],
+    },
+  ];
+
+  const summary = summarize(sections);
+  return {
+    status:
+      summary.failedRequired > 0
+        ? 'blocked'
+        : summary.failedAdvisory > 0
+          ? 'attention'
+          : 'ready',
+    generatedAt: new Date().toISOString(),
+    summary,
+    sections,
+  };
+}


### PR DESCRIPTION
## Summary
- add owner-only production release diagnostics combining setup preflight, release gates, and operations safety checks
- expose the checklist in Settings with refresh support and mock admin data
- document the production release diagnostics flow in the README

Fixes #50

## Verification
- rtk mise exec node@22 -- npx vitest run src/release-diagnostics.test.ts src/setup.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/pages/settings.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/system/release-diagnostics