### PR TITLE
Add backup restore and migration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ success responses and do not mutate live files or services.
 - **Skill Registry** — skills can be enabled/disabled and scoped to all agents, main-only, or channel agents. Visibility can be shared, private, or system. Agents can also call `list_skills` and `search_skills` to find skills related to a user request.
 - **Reports And Research** — agents and admins can request report jobs, outline approval, Markdown/HTML/DOCX/PDF exports, Playwright-backed research notes, and optional official NotebookLM Enterprise configuration.
 - **Unified Approvals** — risky actions such as provider fallback, repo changes, PR creation, report delivery, publishing, uploads, external messages, and tool actions flow through `/api/approvals` and the dashboard Approvals inbox. Approval records include provenance (`source`, `correlationId`, `policyDecisionId`), action/resource previews, expiry metadata, and server-side filters for status, risk, kind, requester, target type, correlation ID, and created date range. Expired pending approvals are marked `expired` and cannot be approved or denied later.
+- **Backup, Restore, And Migration** — owners can create essential or full backups, download encrypted archives, configure automatic backup cadence/retention, review manual restore steps, and check legacy NanoClaw migration readiness from the dashboard Backup page.
 
 ### Default Integrations
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ This roadmap focuses on making NanoCrab more Hermes/OpenClaw-like while keeping 
 - Better terminal controls exist in the dashboard: named shell session id, reconnect, clear, copy transcript, and xterm output.
 - Standalone cleanup is implemented: NanoCrab is treated as its own product with NanoCrab-first code, plugins, skills, MCP names, container names, docs, and migration tooling.
 - P0 closure sweep complete: non-epic P0 issues for cockpit/approvals, provider hardening, memory/skill review surfaces, timeline/router safety, GitHub coding jobs, policy/audit/dry-run controls, connector boundaries, and first-run setup are closed. Remaining P0-labeled GitHub issues are roadmap epics with lower-priority follow-up children still open.
-- Still future work: richer CI-status visualization, mobile coding-agent chat commands, backup/restore UI, more MCP source connectors, production release diagnostics, and continued dashboard UX polish.
+- Still future work: richer CI-status visualization, mobile coding-agent chat commands, more MCP source connectors, and continued dashboard UX polish.
 
 ---
 

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2648,6 +2648,37 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       ],
     };
   }
+  if (pathname === '/backup/auto-config') {
+    return { enabled: true, schedule: 'weekly', keepCount: 4 };
+  }
+  if (pathname === '/backup/migration-status') {
+    return {
+      command: 'npm run migrate:nanocrab',
+      summary: { legacyFound: 1, readyToMigrate: 1, targetConflicts: 0 },
+      checks: [
+        {
+          id: 'config',
+          label: 'Configuration directory',
+          legacyPath: '/home/mock/.config/nanoclaw',
+          targetPath: '/home/mock/.config/nanocrab',
+          legacyExists: true,
+          targetExists: false,
+          status: 'ready',
+          detail: 'Legacy state can be migrated safely',
+        },
+        {
+          id: 'launch-agent',
+          label: 'macOS LaunchAgent',
+          legacyPath: '/home/mock/Library/LaunchAgents/com.nanoclaw.plist',
+          targetPath: '/home/mock/Library/LaunchAgents/com.nanocrab.plist',
+          legacyExists: false,
+          targetExists: false,
+          status: 'not-needed',
+          detail: 'No legacy NanoClaw state found',
+        },
+      ],
+    };
+  }
   if (pathname === '/backup/restore-guide') {
     return {
       steps: [

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -5917,9 +5917,11 @@ function renderSessionTranscript(messages, stats) {
 
 // Backup
 async function renderBackup(el) {
-  const [data, guide] = await Promise.all([
+  const [data, guide, autoConfig, migration] = await Promise.all([
     api('/backup'),
     api('/backup/restore-guide'),
+    api('/backup/auto-config'),
+    api('/backup/migration-status'),
   ]);
 
   el.innerHTML = `
@@ -5956,6 +5958,51 @@ async function renderBackup(el) {
         <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--border)">
           <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:8px">Notes</div>
           ${guide.notes.map((n) => `<div style="font-size:12px;color:var(--text-muted);padding:4px 0">\u2022 ${esc(n)}</div>`).join('')}
+        </div>
+      </div>
+    </div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+      <div class="card">
+        <div class="card-title">Automatic Backups</div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;align-items:end">
+          <label style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text)">
+            <input type="checkbox" id="backup-auto-enabled" ${autoConfig.enabled ? 'checked' : ''}>
+            Enabled
+          </label>
+          <div class="form-group" style="margin:0">
+            <label>Schedule</label>
+            <select id="backup-auto-schedule">
+              <option value="daily" ${autoConfig.schedule === 'daily' ? 'selected' : ''}>Daily</option>
+              <option value="weekly" ${autoConfig.schedule !== 'daily' ? 'selected' : ''}>Weekly</option>
+            </select>
+          </div>
+          <div class="form-group" style="margin:0">
+            <label>Keep</label>
+            <input id="backup-auto-keep" type="number" min="1" max="20" value="${Number(autoConfig.keepCount || 4)}">
+          </div>
+          <button class="btn btn-sm btn-primary" onclick="saveAutoBackupConfig(this)">Save</button>
+        </div>
+        <div style="font-size:11px;color:var(--text-muted);margin-top:10px">Automatic backups create essential-only archives and prune old automatic archives after the configured count.</div>
+      </div>
+      <div class="card">
+        <div class="card-title">Migration Readiness</div>
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
+          <span class="badge ${migration.summary.legacyFound === 0 ? 'badge-success' : migration.summary.targetConflicts > 0 ? 'badge-warning' : 'badge-info'}">${migration.summary.legacyFound === 0 ? 'No legacy state' : `${migration.summary.legacyFound} legacy item(s)`}</span>
+          <code style="font-size:12px;color:var(--text-secondary)">${esc(migration.command)}</code>
+        </div>
+        <div style="display:grid;gap:8px">
+          ${migration.checks
+            .map(
+              (check) => `
+              <div style="padding:9px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+                <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+                  <strong style="font-size:12px;color:var(--text)">${esc(check.label)}</strong>
+                  <span class="badge ${check.status === 'not-needed' ? 'badge-success' : check.status === 'ready' ? 'badge-info' : 'badge-warning'}">${check.status === 'not-needed' ? 'OK' : check.status === 'ready' ? 'Ready' : 'Review'}</span>
+                </div>
+                <div style="font-size:11px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(check.detail)}</div>
+              </div>`,
+            )
+            .join('')}
         </div>
       </div>
     </div>
@@ -6013,8 +6060,8 @@ window.createBackup = async (includeAll, btnEl) => {
 window.downloadEncryptedBackup = async (filename) => {
   const passphrase = prompt('Enter a passphrase for encryption:');
   if (!passphrase) return;
-  if (passphrase.length < 4) {
-    toast('Passphrase too short (min 4 characters)', 'warning');
+  if (passphrase.length < 8) {
+    toast('Passphrase too short (min 8 characters)', 'warning');
     return;
   }
   try {
@@ -6043,6 +6090,34 @@ window.downloadEncryptedBackup = async (filename) => {
     toast('Encrypted backup downloaded', 'success');
   } catch (e) {
     toast('Download failed: ' + e.message, 'error');
+  }
+};
+
+window.saveAutoBackupConfig = async (btnEl) => {
+  const origText = btnEl.textContent;
+  btnEl.disabled = true;
+  btnEl.textContent = 'Saving...';
+  try {
+    const r = await api('/backup/auto-config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        enabled: document.getElementById('backup-auto-enabled')?.checked,
+        schedule: document.getElementById('backup-auto-schedule')?.value,
+        keepCount: document.getElementById('backup-auto-keep')?.value,
+      }),
+    });
+    if (r.ok) {
+      toast('Auto-backup settings saved', 'success');
+      navigate('backup');
+    } else {
+      toast(r.error || 'Failed to save auto-backup settings', 'error');
+      btnEl.disabled = false;
+      btnEl.textContent = origText;
+    }
+  } catch (e) {
+    toast('Failed: ' + e.message, 'error');
+    btnEl.disabled = false;
+    btnEl.textContent = origText;
   }
 };
 

--- a/src/admin/routes/backup.ts
+++ b/src/admin/routes/backup.ts
@@ -1,5 +1,5 @@
 import express, { Router, Request, Response } from 'express';
-import { execFileSync, execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -7,143 +7,31 @@ import path from 'path';
 import { STORE_DIR, DATA_DIR, GROUPS_DIR } from '../../config.js';
 import { auditLog } from '../security.js';
 import { logger } from '../../logger.js';
+import {
+  defaultBackupDir,
+  formatBackupSize,
+  getBackupPaths,
+  getMigrationStatus,
+  isValidBackupFilename,
+  listBackupStatus,
+  restoreGuide,
+} from '../../backup-service.js';
 
 const router = Router();
 const PROJECT_ROOT = process.cwd();
-const BACKUP_DIR = path.join(PROJECT_ROOT, 'backups');
-
-interface BackupManifest {
-  version: string;
-  created: string;
-  hostname: string;
-  contents: string[];
-  size: number;
-}
-
-// Directories and files to back up
-function getBackupPaths(): Array<{
-  path: string;
-  label: string;
-  critical: boolean;
-}> {
-  const home = process.env.HOME || '/root';
-  return [
-    {
-      path: path.join(PROJECT_ROOT, '.env'),
-      label: '.env (credentials)',
-      critical: true,
-    },
-    {
-      path: path.join(PROJECT_ROOT, '.mcp.json'),
-      label: '.mcp.json',
-      critical: false,
-    },
-    {
-      path: path.join(STORE_DIR),
-      label: 'store/ (database, auth, configs)',
-      critical: true,
-    },
-    {
-      path: path.join(GROUPS_DIR),
-      label: 'groups/ (memory, conversations, attachments)',
-      critical: true,
-    },
-    {
-      path: path.join(DATA_DIR),
-      label: 'data/ (sessions, codex)',
-      critical: false,
-    },
-    {
-      path: path.join(PROJECT_ROOT, 'site'),
-      label: 'site/ (landing page)',
-      critical: false,
-    },
-    {
-      path: path.join(PROJECT_ROOT, 'logs'),
-      label: 'logs/ (system logs)',
-      critical: false,
-    },
-    {
-      path: path.join(home, '.config', 'nanocrab'),
-      label: '~/.config/nanocrab/ (mount allowlist)',
-      critical: false,
-    },
-    {
-      path: path.join(home, '.local', 'share', 'signal-cli'),
-      label: '~/.local/share/signal-cli/ (Signal account)',
-      critical: true,
-    },
-  ];
-}
-
-function getSize(p: string): number {
-  try {
-    if (!fs.existsSync(p)) return 0;
-    const stat = fs.statSync(p);
-    if (stat.isFile()) return stat.size;
-    const output = execFileSync('du', ['-sb', p], {
-      encoding: 'utf-8',
-      timeout: 10000,
-    }).trim();
-    return parseInt(output.split('\t')[0]) || 0;
-  } catch {
-    return 0;
-  }
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
-  if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
-  return (bytes / 1073741824).toFixed(1) + ' GB';
-}
+const BACKUP_DIR = defaultBackupDir({ projectRoot: PROJECT_ROOT });
 
 // List what would be backed up + existing backups
 router.get('/', (_req: Request, res: Response) => {
-  const paths = getBackupPaths();
-  const items = paths.map((p) => ({
-    ...p,
-    exists: fs.existsSync(p.path),
-    size: getSize(p.path),
-    sizeFormatted: formatSize(getSize(p.path)),
-  }));
-
-  // List existing backups
-  const backups: Array<{
-    name: string;
-    size: number;
-    sizeFormatted: string;
-    created: string;
-  }> = [];
-  try {
-    if (fs.existsSync(BACKUP_DIR)) {
-      for (const file of fs
-        .readdirSync(BACKUP_DIR)
-        .filter((f) => f.endsWith('.tar.gz'))
-        .sort()
-        .reverse()) {
-        const stat = fs.statSync(path.join(BACKUP_DIR, file));
-        backups.push({
-          name: file,
-          size: stat.size,
-          sizeFormatted: formatSize(stat.size),
-          created: stat.mtime.toISOString(),
-        });
-      }
-    }
-  } catch {
-    /* ok */
-  }
-
-  const totalSize = items.reduce((sum, i) => sum + i.size, 0);
-
-  res.json({
-    items,
-    totalSize,
-    totalSizeFormatted: formatSize(totalSize),
-    backups,
-    backupDir: BACKUP_DIR,
-  });
+  res.json(
+    listBackupStatus({
+      projectRoot: PROJECT_ROOT,
+      storeDir: STORE_DIR,
+      dataDir: DATA_DIR,
+      groupsDir: GROUPS_DIR,
+      backupDir: BACKUP_DIR,
+    }),
+  );
 });
 
 // Create a backup
@@ -157,7 +45,12 @@ router.post('/', (req: Request, res: Response) => {
   const filename = `nanocrab-backup-${timestamp}.tar.gz`;
   const filepath = path.join(BACKUP_DIR, filename);
 
-  const paths = getBackupPaths()
+  const paths = getBackupPaths({
+    projectRoot: PROJECT_ROOT,
+    storeDir: STORE_DIR,
+    dataDir: DATA_DIR,
+    groupsDir: GROUPS_DIR,
+  })
     .filter((p) => includeAll || p.critical)
     .map((p) => p.path)
     .filter((p) => fs.existsSync(p));
@@ -179,7 +72,7 @@ router.post('/', (req: Request, res: Response) => {
       ok: true,
       filename,
       size: stat.size,
-      sizeFormatted: formatSize(stat.size),
+      sizeFormatted: formatBackupSize(stat.size),
       path: filepath,
     });
   } catch (err) {
@@ -192,11 +85,7 @@ router.post('/', (req: Request, res: Response) => {
 // Download a backup (plain)
 router.get('/download/:filename', (req: Request, res: Response) => {
   const filename = req.params.filename as string;
-  if (
-    filename.includes('..') ||
-    filename.includes('/') ||
-    !filename.endsWith('.tar.gz')
-  ) {
+  if (!isValidBackupFilename(filename)) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
   }
@@ -221,11 +110,7 @@ router.post('/download-encrypted/:filename', (req: Request, res: Response) => {
     res.status(400).json({ error: 'Passphrase required (min 8 characters)' });
     return;
   }
-  if (
-    filename.includes('..') ||
-    filename.includes('/') ||
-    !filename.endsWith('.tar.gz')
-  ) {
+  if (!isValidBackupFilename(filename)) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
   }
@@ -297,11 +182,7 @@ router.post(
 // Delete a backup
 router.delete('/:filename', (req: Request, res: Response) => {
   const filename = req.params.filename as string;
-  if (
-    filename.includes('..') ||
-    filename.includes('/') ||
-    !filename.endsWith('.tar.gz')
-  ) {
+  if (!isValidBackupFilename(filename)) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
   }
@@ -319,27 +200,11 @@ router.delete('/:filename', (req: Request, res: Response) => {
 
 // Restore instructions (actual restore is manual for safety)
 router.get('/restore-guide', (_req: Request, res: Response) => {
-  res.json({
-    steps: [
-      '1. Stop NanoCrab: systemctl --user stop nanocrab',
-      '2. Copy backup to new server',
-      '3. Extract: tar -xzf nanocrab-backup-*.tar.gz -C /',
-      '4. Clone the repo: git clone <your-nanocrab-repo-url>',
-      '5. Copy extracted files into the new repo directory',
-      '6. Install dependencies: npm install',
-      '7. Build: npm run build && ./container/build.sh',
-      '8. Set up admin: npx tsx setup/index.ts --step admin -- --username USER --password PASS --domain DOMAIN --port 9743',
-      '9. Start: systemctl --user start nanocrab',
-      '10. Verify channels reconnect and data is intact',
-    ],
-    notes: [
-      'WhatsApp auth may need re-pairing if moving to a different server',
-      'Signal account transfers automatically if signal-cli data is restored',
-      'Telegram bot token works from any server',
-      'Update DNS if the server IP changes',
-      'Caddy will auto-generate new SSL certificates',
-    ],
-  });
+  res.json(restoreGuide());
+});
+
+router.get('/migration-status', (_req: Request, res: Response) => {
+  res.json(getMigrationStatus({ projectRoot: PROJECT_ROOT }));
 });
 
 // --- Auto-backup configuration ---
@@ -416,7 +281,12 @@ export async function checkAutoBackup(): Promise<void> {
   const filename = `nanocrab-auto-${timestamp}.tar.gz`;
   const filepath = path.join(BACKUP_DIR, filename);
 
-  const paths = getBackupPaths()
+  const paths = getBackupPaths({
+    projectRoot: PROJECT_ROOT,
+    storeDir: STORE_DIR,
+    dataDir: DATA_DIR,
+    groupsDir: GROUPS_DIR,
+  })
     .filter((p) => p.critical)
     .map((p) => p.path)
     .filter((p) => fs.existsSync(p));

--- a/src/backup-service.test.ts
+++ b/src/backup-service.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  getMigrationStatus,
+  isValidBackupFilename,
+  listBackupStatus,
+} from './backup-service.js';
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-backup-'));
+  fs.mkdirSync(path.join(root, 'store'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'backups'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.env'), 'ADMIN_PASSWORD_HASH=test\n');
+  fs.writeFileSync(path.join(root, 'store', 'messages.db'), 'sqlite');
+  fs.writeFileSync(path.join(root, 'groups', 'main.json'), '{}');
+  fs.writeFileSync(
+    path.join(root, 'backups', 'nanocrab-backup-2026-06-13.tar.gz'),
+    'archive',
+  );
+  fs.writeFileSync(path.join(root, 'backups', '../ignored.txt'), 'ignored');
+  return root;
+}
+
+describe('backup service', () => {
+  it('lists backup inputs and existing archives', () => {
+    const root = makeRoot();
+    const status = listBackupStatus({
+      projectRoot: root,
+      storeDir: path.join(root, 'store'),
+      dataDir: path.join(root, 'data'),
+      groupsDir: path.join(root, 'groups'),
+      backupDir: path.join(root, 'backups'),
+      homeDir: root,
+    });
+
+    expect(status.backupDir).toBe(path.join(root, 'backups'));
+    expect(status.backups).toEqual([
+      expect.objectContaining({
+        name: 'nanocrab-backup-2026-06-13.tar.gz',
+      }),
+    ]);
+    expect(status.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '.env (credentials)', exists: true }),
+        expect.objectContaining({
+          label: 'store/ (database, auth, configs)',
+          exists: true,
+        }),
+      ]),
+    );
+  });
+
+  it('rejects traversal and non-archive backup filenames', () => {
+    expect(isValidBackupFilename('nanocrab-backup.tar.gz')).toBe(true);
+    expect(isValidBackupFilename('../nanocrab-backup.tar.gz')).toBe(false);
+    expect(isValidBackupFilename('nested/nanocrab-backup.tar.gz')).toBe(false);
+    expect(isValidBackupFilename('nanocrab-backup.tar.gz.enc')).toBe(false);
+  });
+
+  it('reports legacy NanoClaw state that can be migrated', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-migrate-'));
+    fs.mkdirSync(path.join(home, '.config', 'nanoclaw'), { recursive: true });
+
+    const status = getMigrationStatus({ homeDir: home });
+
+    expect(status.summary).toEqual({
+      legacyFound: 1,
+      readyToMigrate: 1,
+      targetConflicts: 0,
+    });
+    expect(status.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'config',
+        status: 'ready',
+      }),
+    );
+  });
+});

--- a/src/backup-service.ts
+++ b/src/backup-service.ts
@@ -1,0 +1,290 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { DATA_DIR, GROUPS_DIR, STORE_DIR } from './config.js';
+
+export interface BackupPath {
+  path: string;
+  label: string;
+  critical: boolean;
+}
+
+export interface BackupItem extends BackupPath {
+  exists: boolean;
+  size: number;
+  sizeFormatted: string;
+}
+
+export interface BackupArchive {
+  name: string;
+  size: number;
+  sizeFormatted: string;
+  created: string;
+}
+
+export interface BackupStatus {
+  items: BackupItem[];
+  totalSize: number;
+  totalSizeFormatted: string;
+  backups: BackupArchive[];
+  backupDir: string;
+}
+
+export interface MigrationCheck {
+  id: string;
+  label: string;
+  legacyPath: string;
+  targetPath: string;
+  legacyExists: boolean;
+  targetExists: boolean;
+  status: 'not-needed' | 'ready' | 'target-exists';
+  detail: string;
+}
+
+export interface MigrationStatus {
+  command: string;
+  checks: MigrationCheck[];
+  summary: {
+    legacyFound: number;
+    readyToMigrate: number;
+    targetConflicts: number;
+  };
+}
+
+export interface BackupServiceOptions {
+  projectRoot?: string;
+  storeDir?: string;
+  dataDir?: string;
+  groupsDir?: string;
+  backupDir?: string;
+  homeDir?: string;
+}
+
+function projectRoot(options: BackupServiceOptions): string {
+  return options.projectRoot || process.cwd();
+}
+
+export function defaultBackupDir(options: BackupServiceOptions = {}): string {
+  return options.backupDir || path.join(projectRoot(options), 'backups');
+}
+
+export function formatBackupSize(bytes: number): string {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
+  return (bytes / 1073741824).toFixed(1) + ' GB';
+}
+
+export function getBackupPaths(
+  options: BackupServiceOptions = {},
+): BackupPath[] {
+  const root = projectRoot(options);
+  const home = options.homeDir || process.env.HOME || '/root';
+  return [
+    {
+      path: path.join(root, '.env'),
+      label: '.env (credentials)',
+      critical: true,
+    },
+    {
+      path: path.join(root, '.mcp.json'),
+      label: '.mcp.json',
+      critical: false,
+    },
+    {
+      path: options.storeDir || STORE_DIR,
+      label: 'store/ (database, auth, configs)',
+      critical: true,
+    },
+    {
+      path: options.groupsDir || GROUPS_DIR,
+      label: 'groups/ (memory, conversations, attachments)',
+      critical: true,
+    },
+    {
+      path: options.dataDir || DATA_DIR,
+      label: 'data/ (sessions, codex)',
+      critical: false,
+    },
+    {
+      path: path.join(root, 'site'),
+      label: 'site/ (landing page)',
+      critical: false,
+    },
+    {
+      path: path.join(root, 'logs'),
+      label: 'logs/ (system logs)',
+      critical: false,
+    },
+    {
+      path: path.join(home, '.config', 'nanocrab'),
+      label: '~/.config/nanocrab/ (mount allowlist)',
+      critical: false,
+    },
+    {
+      path: path.join(home, '.local', 'share', 'signal-cli'),
+      label: '~/.local/share/signal-cli/ (Signal account)',
+      critical: true,
+    },
+  ];
+}
+
+export function getPathSize(targetPath: string): number {
+  try {
+    if (!fs.existsSync(targetPath)) return 0;
+    const stat = fs.statSync(targetPath);
+    if (stat.isFile()) return stat.size;
+    if (!stat.isDirectory()) return 0;
+    return fs
+      .readdirSync(targetPath)
+      .reduce(
+        (sum, entry) => sum + getPathSize(path.join(targetPath, entry)),
+        0,
+      );
+  } catch {
+    return 0;
+  }
+}
+
+export function isValidBackupFilename(filename: string): boolean {
+  return (
+    !filename.includes('..') &&
+    !filename.includes('/') &&
+    !filename.includes('\\') &&
+    filename.endsWith('.tar.gz')
+  );
+}
+
+export function listBackupStatus(
+  options: BackupServiceOptions = {},
+): BackupStatus {
+  const backupDir = defaultBackupDir(options);
+  const items = getBackupPaths(options).map((item) => {
+    const size = getPathSize(item.path);
+    return {
+      ...item,
+      exists: fs.existsSync(item.path),
+      size,
+      sizeFormatted: formatBackupSize(size),
+    };
+  });
+
+  const backups: BackupArchive[] = [];
+  try {
+    if (fs.existsSync(backupDir)) {
+      for (const file of fs
+        .readdirSync(backupDir)
+        .filter((name) => isValidBackupFilename(name))
+        .sort()
+        .reverse()) {
+        const stat = fs.statSync(path.join(backupDir, file));
+        backups.push({
+          name: file,
+          size: stat.size,
+          sizeFormatted: formatBackupSize(stat.size),
+          created: stat.mtime.toISOString(),
+        });
+      }
+    }
+  } catch {
+    /* ok */
+  }
+
+  const totalSize = items.reduce((sum, item) => sum + item.size, 0);
+  return {
+    items,
+    totalSize,
+    totalSizeFormatted: formatBackupSize(totalSize),
+    backups,
+    backupDir,
+  };
+}
+
+export function restoreGuide(): { steps: string[]; notes: string[] } {
+  return {
+    steps: [
+      '1. Stop NanoCrab: systemctl --user stop nanocrab',
+      '2. Copy backup to new server',
+      '3. Extract: tar -xzf nanocrab-backup-*.tar.gz -C /',
+      '4. Clone the repo: git clone <your-nanocrab-repo-url>',
+      '5. Copy extracted files into the new repo directory',
+      '6. Install dependencies: npm install',
+      '7. Build: npm run build && ./container/build.sh',
+      '8. Set up admin: npx tsx setup/index.ts --step admin -- --username USER --password PASS --domain DOMAIN --port 9743',
+      '9. Start: systemctl --user start nanocrab',
+      '10. Verify channels reconnect and data is intact',
+    ],
+    notes: [
+      'WhatsApp auth may need re-pairing if moving to a different server',
+      'Signal account transfers automatically if signal-cli data is restored',
+      'Telegram bot token works from any server',
+      'Update DNS if the server IP changes',
+      'Caddy will auto-generate new SSL certificates',
+    ],
+  };
+}
+
+export function getMigrationStatus(
+  options: BackupServiceOptions = {},
+): MigrationStatus {
+  const home = options.homeDir || os.homedir();
+  const pairs = [
+    {
+      id: 'config',
+      label: 'Configuration directory',
+      legacyPath: path.join(home, '.config', 'nanoclaw'),
+      targetPath: path.join(home, '.config', 'nanocrab'),
+    },
+    {
+      id: 'launch-agent',
+      label: 'macOS LaunchAgent',
+      legacyPath: path.join(
+        home,
+        'Library',
+        'LaunchAgents',
+        'com.nanoclaw.plist',
+      ),
+      targetPath: path.join(
+        home,
+        'Library',
+        'LaunchAgents',
+        'com.nanocrab.plist',
+      ),
+    },
+  ];
+
+  const checks = pairs.map((pair): MigrationCheck => {
+    const legacyExists = fs.existsSync(pair.legacyPath);
+    const targetExists = fs.existsSync(pair.targetPath);
+    const status = !legacyExists
+      ? 'not-needed'
+      : targetExists
+        ? 'target-exists'
+        : 'ready';
+    return {
+      ...pair,
+      legacyExists,
+      targetExists,
+      status,
+      detail:
+        status === 'not-needed'
+          ? 'No legacy NanoClaw state found'
+          : status === 'ready'
+            ? 'Legacy state can be migrated safely'
+            : 'NanoCrab target already exists; migration will preserve the legacy source as a timestamped backup',
+    };
+  });
+
+  return {
+    command: 'npm run migrate:nanocrab',
+    checks,
+    summary: {
+      legacyFound: checks.filter((check) => check.legacyExists).length,
+      readyToMigrate: checks.filter((check) => check.status === 'ready').length,
+      targetConflicts: checks.filter(
+        (check) => check.status === 'target-exists',
+      ).length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract backup listing, filename safety, restore guide, and migration readiness into a backup service
- add Backup page controls for automatic backup cadence/retention and legacy NanoClaw migration readiness
- include mock-mode backup automation/migration data and update README/roadmap docs

Fixes #48

## Verification
- rtk mise exec node@22 -- npx vitest run src/backup-service.test.ts src/release-diagnostics.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/app.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/backup, /api/backup/auto-config, and /api/backup/migration-status