### PR TITLE
Add GitHub connector health

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Additional plugins can be installed from git URLs via the Marketplace page, or c
 - **Isolated Coding Jobs** — WhatsApp/Signal/Telegram agents can request repo coding jobs through MCP; an ephemeral coding container clones and edits inside `data/coding-workspaces`
 - **Scheduled Tasks** — recurring coding jobs (hourly, daily, weekly)
 - **GitHub Autofix Pipeline** — webhook-driven: issue created/labeled → approval-gated coding job → reviewed PR publish → bot notifies you
+- **GitHub Connector Health** — Webhooks shows the receiver URL, secret/target/event setup, recent deliveries, and read-only connector health checks without revealing credentials
 - **PR Review** — an agent reviews every new PR and posts comments
 
 Coding jobs are available only from the main group. Add

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2483,6 +2483,60 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       },
     ];
   }
+  if (pathname === '/webhooks/github-health') {
+    return {
+      status: 'attention',
+      webhookUrl: 'https://nanocrab.example.com/api/webhooks/github',
+      generatedAt: iso(0),
+      summary: { total: 6, passed: 5, failedRequired: 0, failedAdvisory: 1 },
+      checks: [
+        {
+          id: 'github-token',
+          label: 'GitHub API token',
+          ok: true,
+          severity: 'required',
+          detail:
+            'GitHub token is configured for connector and coding-job API calls',
+        },
+        {
+          id: 'webhook-enabled',
+          label: 'Webhook receiver',
+          ok: true,
+          severity: 'advisory',
+          detail: 'GitHub webhook receiver is enabled',
+        },
+        {
+          id: 'webhook-secret',
+          label: 'Webhook secret',
+          ok: true,
+          severity: 'required',
+          detail: 'Webhook secret is configured',
+        },
+        {
+          id: 'target-group',
+          label: 'Notification target',
+          ok: true,
+          severity: 'required',
+          detail: 'Target group is configured',
+        },
+        {
+          id: 'event-selection',
+          label: 'Event selection',
+          ok: false,
+          severity: 'advisory',
+          detail: 'Recommended events are not all selected',
+          hint: 'Select push, pull_request, and issues events for coding and autofix workflows',
+        },
+        {
+          id: 'recent-delivery',
+          label: 'Recent delivery',
+          ok: true,
+          severity: 'advisory',
+          detail: 'Most recent event: issues on henrikogaard/nanocrab',
+        },
+      ],
+    };
+  }
   if (pathname === '/logs/system') {
     return {
       lines: [

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -4057,10 +4057,11 @@ window.validatePath = async () => {
 
 // Webhooks
 async function renderWebhooks(el) {
-  const [config, events, groups] = await Promise.all([
+  const [config, events, groups, health] = await Promise.all([
     api('/webhooks/config'),
     api('/webhooks/events'),
     api('/groups'),
+    api('/webhooks/github-health'),
   ]);
   const webhookUrl = `${window.location.origin}/api/webhooks/github`;
 
@@ -4095,6 +4096,25 @@ async function renderWebhooks(el) {
       </div>
       <div class="card">
         <div class="card-title">Setup Instructions</div>
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px">
+          <span class="badge ${health.status === 'ready' ? 'badge-success' : health.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(health.status)}</span>
+          <span style="font-size:12px;color:var(--text-muted)">${health.summary.passed}/${health.summary.total} checks passing</span>
+        </div>
+        <div style="display:grid;gap:6px;margin-bottom:12px">
+          ${health.checks
+            .map(
+              (check) => `
+            <div style="padding:8px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+              <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+                <strong style="font-size:12px;color:var(--text)">${esc(check.label)}</strong>
+                <span class="badge ${check.ok ? 'badge-success' : check.severity === 'required' ? 'badge-error' : 'badge-warning'}">${check.ok ? 'OK' : check.severity === 'required' ? 'Block' : 'Warn'}</span>
+              </div>
+              <div style="font-size:11px;color:var(--text-muted);margin-top:4px">${esc(check.detail)}</div>
+              ${check.hint && !check.ok ? `<div style="font-size:11px;color:var(--warning);margin-top:4px">${esc(check.hint)}</div>` : ''}
+            </div>`,
+            )
+            .join('')}
+        </div>
         <ol style="font-size:13px;color:var(--text-secondary);line-height:1.8;padding-left:20px">
           <li>Go to your GitHub repo → Settings → Webhooks → Add webhook</li>
           <li>Paste the Webhook URL above</li>

--- a/src/admin/routes/webhooks.ts
+++ b/src/admin/routes/webhooks.ts
@@ -9,6 +9,7 @@ import { getState } from '../state.js';
 import { auditLog } from '../security.js';
 import { logger } from '../../logger.js';
 import { handleAutofixWebhook } from '../plugins/autofix/routes.js';
+import { buildGitHubConnectorHealth } from '../../github-connector-health.js';
 
 const router = Router();
 const CONFIG_PATH = path.join(STORE_DIR, 'webhook-config.json');
@@ -47,6 +48,26 @@ function logEvent(event: Record<string, unknown>): void {
   }
 }
 
+function loadEvents(limit = 50): Record<string, unknown>[] {
+  try {
+    const content = fs.readFileSync(EVENTS_PATH, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    return lines
+      .slice(-limit)
+      .reverse()
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 // Config CRUD (protected by requireAuth in index.ts)
 router.get('/config', (_req: Request, res: Response) => {
   const config = loadConfig();
@@ -68,24 +89,33 @@ router.put('/config', (req: Request, res: Response) => {
 });
 
 router.get('/events', (_req: Request, res: Response) => {
-  try {
-    const content = fs.readFileSync(EVENTS_PATH, 'utf-8');
-    const lines = content.trim().split('\n').filter(Boolean);
-    const events = lines
-      .slice(-50)
-      .reverse()
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          return null;
-        }
-      })
-      .filter(Boolean);
-    res.json(events);
-  } catch {
-    res.json([]);
-  }
+  res.json(loadEvents());
+});
+
+router.get('/github-health', (req: Request, res: Response) => {
+  const env = readEnvFile(['GITHUB_TOKEN', 'GITHUB_WEBHOOK_SECRET']);
+  const config = loadConfig();
+  const state = getState();
+  const groups = state.registeredGroups();
+  const webhookSecret =
+    config.secret ||
+    process.env.GITHUB_WEBHOOK_SECRET ||
+    env.GITHUB_WEBHOOK_SECRET ||
+    '';
+  const token = process.env.GITHUB_TOKEN || env.GITHUB_TOKEN || '';
+  const protocol = req.protocol || 'http';
+  const host = req.get('host') || 'localhost';
+
+  res.json(
+    buildGitHubConnectorHealth({
+      webhookUrl: `${protocol}://${host}/api/webhooks/github`,
+      config,
+      events: loadEvents(),
+      tokenConfigured: !!token,
+      webhookSecretConfigured: !!webhookSecret,
+      targetGroupExists: Object.keys(groups).includes(config.targetJid),
+    }),
+  );
 });
 
 router.delete('/events', (req: Request, res: Response) => {

--- a/src/github-connector-health.test.ts
+++ b/src/github-connector-health.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGitHubConnectorHealth } from './github-connector-health.js';
+
+describe('github connector health', () => {
+  it('reports ready when GitHub token, webhook setup, and events are present', () => {
+    const result = buildGitHubConnectorHealth({
+      webhookUrl: 'https://example.com/api/webhooks/github',
+      config: {
+        enabled: true,
+        secret: 'not-returned',
+        events: ['push', 'pull_request', 'issues'],
+        targetJid: 'wa:main',
+      },
+      events: [
+        {
+          timestamp: '2026-06-13T10:00:00.000Z',
+          event: 'issues',
+          repo: 'owner/repo',
+          status: 'handled',
+        },
+      ],
+      tokenConfigured: true,
+      webhookSecretConfigured: true,
+      targetGroupExists: true,
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('ready');
+    expect(result.summary.failedRequired).toBe(0);
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ id: 'github-token', ok: true }),
+    );
+  });
+
+  it('blocks enabled webhook setup without leaking secret values', () => {
+    const result = buildGitHubConnectorHealth({
+      webhookUrl: 'https://example.com/api/webhooks/github',
+      config: {
+        enabled: true,
+        secret: 'super-secret-webhook-value',
+        events: ['push'],
+        targetJid: 'wa:missing',
+      },
+      events: [],
+      tokenConfigured: false,
+      webhookSecretConfigured: false,
+      targetGroupExists: false,
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'github-token',
+        ok: false,
+        severity: 'required',
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain('super-secret-webhook-value');
+  });
+});

--- a/src/github-connector-health.ts
+++ b/src/github-connector-health.ts
@@ -1,0 +1,154 @@
+export type GitHubConnectorHealthStatus = 'ready' | 'attention' | 'blocked';
+export type GitHubConnectorHealthSeverity = 'required' | 'advisory';
+
+export interface GitHubWebhookConfigView {
+  enabled: boolean;
+  secret?: string;
+  events: string[];
+  targetJid?: string;
+}
+
+export interface GitHubWebhookEventView {
+  timestamp?: string;
+  event?: string;
+  repo?: string;
+  status?: string;
+}
+
+export interface GitHubConnectorHealthCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  severity: GitHubConnectorHealthSeverity;
+  detail: string;
+  hint?: string;
+}
+
+export interface GitHubConnectorHealthResult {
+  status: GitHubConnectorHealthStatus;
+  webhookUrl: string;
+  generatedAt: string;
+  summary: {
+    total: number;
+    passed: number;
+    failedRequired: number;
+    failedAdvisory: number;
+  };
+  checks: GitHubConnectorHealthCheck[];
+}
+
+export interface GitHubConnectorHealthInput {
+  webhookUrl: string;
+  config: GitHubWebhookConfigView;
+  events: GitHubWebhookEventView[];
+  tokenConfigured: boolean;
+  webhookSecretConfigured: boolean;
+  targetGroupExists: boolean;
+  now?: Date;
+}
+
+function summarize(checks: GitHubConnectorHealthCheck[]) {
+  const failedRequired = checks.filter(
+    (check) => !check.ok && check.severity === 'required',
+  ).length;
+  const failedAdvisory = checks.filter(
+    (check) => !check.ok && check.severity === 'advisory',
+  ).length;
+  return {
+    total: checks.length,
+    passed: checks.filter((check) => check.ok).length,
+    failedRequired,
+    failedAdvisory,
+  };
+}
+
+export function buildGitHubConnectorHealth(
+  input: GitHubConnectorHealthInput,
+): GitHubConnectorHealthResult {
+  const subscribedEvents = new Set(input.config.events || []);
+  const recommendedEvents = ['push', 'pull_request', 'issues'];
+  const hasRecommendedEvents = recommendedEvents.every((event) =>
+    subscribedEvents.has(event),
+  );
+  const recentEvent = input.events.find((event) => !!event.timestamp);
+
+  const checks: GitHubConnectorHealthCheck[] = [
+    {
+      id: 'github-token',
+      label: 'GitHub API token',
+      ok: input.tokenConfigured,
+      severity: 'required',
+      detail: input.tokenConfigured
+        ? 'GitHub token is configured for connector and coding-job API calls'
+        : 'GitHub token is missing',
+      hint: 'Set GITHUB_TOKEN in Credentials before using GitHub issue pickup or coding jobs',
+    },
+    {
+      id: 'webhook-enabled',
+      label: 'Webhook receiver',
+      ok: input.config.enabled,
+      severity: 'advisory',
+      detail: input.config.enabled
+        ? 'GitHub webhook receiver is enabled'
+        : 'GitHub webhook receiver is disabled',
+      hint: 'Enable the receiver after the GitHub repository webhook is configured',
+    },
+    {
+      id: 'webhook-secret',
+      label: 'Webhook secret',
+      ok: input.webhookSecretConfigured,
+      severity: input.config.enabled ? 'required' : 'advisory',
+      detail: input.webhookSecretConfigured
+        ? 'Webhook secret is configured'
+        : 'Webhook secret is missing',
+      hint: 'Set a shared secret in NanoCrab and GitHub; secrets are never shown after saving',
+    },
+    {
+      id: 'target-group',
+      label: 'Notification target',
+      ok: !!input.config.targetJid && input.targetGroupExists,
+      severity: input.config.enabled ? 'required' : 'advisory',
+      detail:
+        input.config.targetJid && input.targetGroupExists
+          ? 'Target group is configured'
+          : input.config.targetJid
+            ? 'Configured target group is not currently registered'
+            : 'No target group selected',
+      hint: 'Select a registered group to receive GitHub webhook summaries',
+    },
+    {
+      id: 'event-selection',
+      label: 'Event selection',
+      ok: hasRecommendedEvents,
+      severity: 'advisory',
+      detail: hasRecommendedEvents
+        ? 'Push, pull request, and issue events are selected'
+        : 'Recommended events are not all selected',
+      hint: 'Select push, pull_request, and issues events for coding and autofix workflows',
+    },
+    {
+      id: 'recent-delivery',
+      label: 'Recent delivery',
+      ok: !!recentEvent,
+      severity: 'advisory',
+      detail: recentEvent
+        ? `Most recent event: ${recentEvent.event || 'unknown'} on ${recentEvent.repo || 'unknown repo'}`
+        : 'No webhook events have been received yet',
+      hint: 'Use GitHub Webhook Settings -> Recent Deliveries to send a ping after setup',
+    },
+  ];
+
+  const summary = summarize(checks);
+  return {
+    status:
+      summary.failedRequired > 0
+        ? 'blocked'
+        : summary.failedAdvisory > 0
+          ? 'attention'
+          : 'ready',
+    webhookUrl: input.webhookUrl,
+    generatedAt: (input.now || new Date()).toISOString(),
+    summary,
+    checks,
+  };
+}


### PR DESCRIPTION
## Summary
- add read-only GitHub connector health checks for token, webhook secret, receiver state, target group, events, and recent deliveries
- surface the health checklist on the Webhooks dashboard page without exposing secret values
- include mock-mode health data and README documentation

Fixes #42

## Verification
- rtk mise exec node@22 -- npx vitest run src/github-connector-health.test.ts src/backup-service.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/app.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/webhooks/github-health