### PR TITLE
Add Infomaniak document workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ Optional dashboard presets can add provider integrations. NanoCrab currently
 includes an opt-in Infomaniak kSuite preset and an `infomaniak-ksuite` skill for
 mail, kDrive, and DAV workflows. Google Workspace remains a bundled skill and
 credential surface for deployments that provide a compatible MCP server.
+The MCP dashboard also reports Infomaniak document workflow readiness, covering
+kDrive search/read, report drafting from approved sources, approval-gated
+uploads/sharing, and optional DAV/mail context.
 
 ### Security
 

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2015,6 +2015,88 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       },
     ];
   }
+  if (pathname === '/mcp/infomaniak-workflows') {
+    return {
+      status: 'attention',
+      generatedAt: iso(0),
+      summary: { total: 5, ready: 3, attention: 2, blocked: 0 },
+      checks: [
+        {
+          id: 'preset-installed',
+          label: 'Infomaniak MCP preset',
+          ok: true,
+          severity: 'required',
+          detail: 'Infomaniak kSuite MCP server is installed',
+        },
+        {
+          id: 'kdrive-credentials',
+          label: 'kDrive credentials',
+          ok: true,
+          severity: 'required',
+          detail: 'INFOMANIAK_TOKEN and KDRIVE_ID are configured',
+        },
+        {
+          id: 'dav-credentials',
+          label: 'DAV credentials',
+          ok: false,
+          severity: 'advisory',
+          detail: 'DAV credentials are missing',
+          hint: 'Add DAV_USER and DAV_PASSWORD to enable contact/calendar workflows',
+        },
+        {
+          id: 'write-approval',
+          label: 'Write approval gate',
+          ok: true,
+          severity: 'required',
+          detail: 'Write-capable workflows require approval',
+        },
+      ],
+      workflows: [
+        {
+          id: 'kdrive-search-read',
+          label: 'Search and summarize kDrive documents',
+          status: 'ready',
+          detail: 'Agents can find approved kDrive sources and summarize them',
+          tools: ['mcp__infomaniak__*', 'infomaniak-ksuite'],
+          approvalRequired: false,
+        },
+        {
+          id: 'document-draft',
+          label: 'Draft reports from approved kDrive sources',
+          status: 'ready',
+          detail:
+            'Document drafts can combine approved kDrive sources with report skills',
+          tools: ['mcp__infomaniak__*', 'report-writer'],
+          approvalRequired: false,
+        },
+        {
+          id: 'upload-share',
+          label: 'Upload or share document deliverables',
+          status: 'ready',
+          detail: 'Write-capable kDrive actions are available behind approval',
+          tools: ['mcp__infomaniak__*'],
+          approvalRequired: true,
+        },
+        {
+          id: 'dav-context',
+          label: 'Use DAV contacts and calendar context',
+          status: 'attention',
+          detail: 'DAV-backed context is optional and currently incomplete',
+          tools: ['mcp__infomaniak__*', 'meeting-briefing'],
+          approvalRequired: false,
+        },
+        {
+          id: 'mail-context',
+          label: 'Use mail as document context',
+          status: 'attention',
+          detail:
+            'Mail-backed document context is optional and currently incomplete',
+          tools: ['mcp__infomaniak__*', 'email-assistant'],
+          approvalRequired: false,
+        },
+      ],
+    };
+  }
   if (pathname === '/providers') return providers();
   if (pathname === '/memory') {
     return [

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -2589,9 +2589,10 @@ window.deleteCredential = async (key, btnEl) => {
 
 // MCP Servers
 async function renderMcp(el) {
-  const [health, presets] = await Promise.all([
+  const [health, presets, infomaniakWorkflows] = await Promise.all([
     api('/mcp/health'),
     api('/mcp/presets').catch(() => []),
+    api('/mcp/infomaniak-workflows').catch(() => null),
   ]);
   const servers = health.servers || [];
   el.innerHTML = `
@@ -2629,6 +2630,49 @@ async function renderMcp(el) {
         </div>`,
         )
         .join('')}
+    </div>`
+        : ''
+    }
+    ${
+      infomaniakWorkflows
+        ? `<div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:10px">
+        <div>
+          <div class="card-title" style="margin:0">Infomaniak Document Workflows</div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">kDrive, DAV, and mail-backed document tasks using the Infomaniak kSuite MCP preset.</div>
+        </div>
+        <span class="badge ${infomaniakWorkflows.status === 'ready' ? 'badge-success' : infomaniakWorkflows.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(infomaniakWorkflows.status)}</span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:8px;margin-bottom:12px">
+        ${infomaniakWorkflows.workflows
+          .map(
+            (workflow) => `
+          <div style="padding:9px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+            <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+              <strong style="font-size:12px;color:var(--text)">${esc(workflow.label)}</strong>
+              <span class="badge ${workflow.status === 'ready' ? 'badge-success' : workflow.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(workflow.status)}</span>
+            </div>
+            <div style="font-size:11px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(workflow.detail)}</div>
+            ${workflow.approvalRequired ? '<div style="font-size:11px;color:var(--warning);margin-top:5px">Requires explicit approval before external writes.</div>' : ''}
+          </div>`,
+          )
+          .join('')}
+      </div>
+      <div style="display:grid;gap:6px">
+        ${infomaniakWorkflows.checks
+          .map(
+            (check) => `
+          <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;font-size:12px;padding:7px 8px;border:1px solid var(--border);border-radius:var(--radius-sm)">
+            <div>
+              <strong style="color:var(--text)">${esc(check.label)}</strong>
+              <div style="color:var(--text-muted);margin-top:2px">${esc(check.detail)}</div>
+              ${check.hint && !check.ok ? `<div style="color:var(--warning);margin-top:2px">${esc(check.hint)}</div>` : ''}
+            </div>
+            <span class="badge ${check.ok ? 'badge-success' : check.severity === 'required' ? 'badge-error' : 'badge-warning'}">${check.ok ? 'OK' : check.severity === 'required' ? 'Block' : 'Warn'}</span>
+          </div>`,
+          )
+          .join('')}
+      </div>
     </div>`
         : ''
     }

--- a/src/admin/routes/mcp.ts
+++ b/src/admin/routes/mcp.ts
@@ -9,6 +9,10 @@ import {
   saveConnectorPermissions,
   type ConnectorPermission,
 } from '../../connector-permissions.js';
+import {
+  buildInfomaniakWorkflows,
+  infomaniakSkillPath,
+} from '../../infomaniak-workflows.js';
 
 const router = Router();
 const PROJECT_ROOT = process.cwd();
@@ -170,6 +174,21 @@ router.get('/', (_req: Request, res: Response) => {
 
 router.get('/health', (_req: Request, res: Response) => {
   res.json(getStatus());
+});
+
+router.get('/infomaniak-workflows', (_req: Request, res: Response) => {
+  const status = getStatus();
+  const configured = new Set(loadConfig().map((server) => server.name));
+  res.json(
+    buildInfomaniakWorkflows({
+      servers: status.servers,
+      presets: MCP_PRESETS.map((preset) => ({
+        name: preset.name,
+        installed: configured.has(preset.name),
+      })),
+      skillPath: infomaniakSkillPath(PROJECT_ROOT),
+    }),
+  );
 });
 
 router.get('/presets', (_req: Request, res: Response) => {

--- a/src/infomaniak-workflows.test.ts
+++ b/src/infomaniak-workflows.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildInfomaniakWorkflows } from './infomaniak-workflows.js';
+
+function skillFile(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-infomaniak-'));
+  const file = path.join(
+    root,
+    'container',
+    'skills',
+    'infomaniak-ksuite',
+    'SKILL.md',
+  );
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '# Infomaniak kSuite\n');
+  return file;
+}
+
+const readyServer = {
+  name: 'infomaniak',
+  allEnvSet: true,
+  envStatus: [
+    { key: 'INFOMANIAK_TOKEN', isSet: true },
+    { key: 'KDRIVE_ID', isSet: true },
+    { key: 'MAIL_USER', isSet: true },
+    { key: 'MAIL_PASSWORD', isSet: true },
+    { key: 'DAV_USER', isSet: true },
+    { key: 'DAV_PASSWORD', isSet: true },
+  ],
+  permission: {
+    connectorId: 'infomaniak',
+    scope: 'main' as const,
+    allowedActions: ['*.read', 'tools.expose'],
+    requiresApproval: true,
+    groups: [],
+    agents: [],
+    createdAt: '2026-06-13T10:00:00.000Z',
+    updatedAt: '2026-06-13T10:00:00.000Z',
+  },
+};
+
+describe('infomaniak workflows', () => {
+  it('reports document workflows ready when preset, credentials, permission, and skill are present', () => {
+    const result = buildInfomaniakWorkflows({
+      servers: [readyServer],
+      presets: [{ name: 'infomaniak', installed: true }],
+      skillPath: skillFile(),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('ready');
+    expect(result.summary.ready).toBe(result.summary.total);
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({
+        id: 'upload-share',
+        status: 'ready',
+        approvalRequired: true,
+      }),
+    );
+  });
+
+  it('blocks write-capable document workflow when approval is disabled', () => {
+    const result = buildInfomaniakWorkflows({
+      servers: [
+        {
+          ...readyServer,
+          permission: {
+            ...readyServer.permission,
+            requiresApproval: false,
+          },
+        },
+      ],
+      presets: [{ name: 'infomaniak', installed: true }],
+      skillPath: skillFile(),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'write-approval',
+        ok: false,
+        severity: 'required',
+      }),
+    );
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({ id: 'upload-share', status: 'blocked' }),
+    );
+  });
+});

--- a/src/infomaniak-workflows.ts
+++ b/src/infomaniak-workflows.ts
@@ -1,0 +1,265 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { ConnectorPermission } from './connector-permissions.js';
+
+export type InfomaniakWorkflowStatus = 'ready' | 'attention' | 'blocked';
+export type InfomaniakWorkflowSeverity = 'required' | 'advisory';
+
+export interface InfomaniakWorkflowServer {
+  name: string;
+  allEnvSet?: boolean;
+  envStatus?: Array<{ key: string; isSet: boolean }>;
+  permission?: ConnectorPermission;
+}
+
+export interface InfomaniakWorkflowPreset {
+  name: string;
+  installed?: boolean;
+}
+
+export interface InfomaniakWorkflowItem {
+  id: string;
+  label: string;
+  status: InfomaniakWorkflowStatus;
+  detail: string;
+  tools: string[];
+  approvalRequired: boolean;
+}
+
+export interface InfomaniakWorkflowCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  severity: InfomaniakWorkflowSeverity;
+  detail: string;
+  hint?: string;
+}
+
+export interface InfomaniakWorkflowResult {
+  status: InfomaniakWorkflowStatus;
+  generatedAt: string;
+  summary: {
+    total: number;
+    ready: number;
+    attention: number;
+    blocked: number;
+  };
+  checks: InfomaniakWorkflowCheck[];
+  workflows: InfomaniakWorkflowItem[];
+}
+
+export interface BuildInfomaniakWorkflowInput {
+  servers: InfomaniakWorkflowServer[];
+  presets: InfomaniakWorkflowPreset[];
+  skillPath: string;
+  now?: Date;
+}
+
+const KDRIVE_KEYS = ['INFOMANIAK_TOKEN', 'KDRIVE_ID'];
+const DAV_KEYS = ['DAV_USER', 'DAV_PASSWORD'];
+const MAIL_KEYS = ['MAIL_USER', 'MAIL_PASSWORD'];
+
+function hasEnv(server: InfomaniakWorkflowServer | undefined, key: string) {
+  return !!server?.envStatus?.some(
+    (status) => status.key === key && status.isSet,
+  );
+}
+
+function workflowStatus(
+  ok: boolean,
+  advisoryOnly = false,
+): InfomaniakWorkflowStatus {
+  if (ok) return 'ready';
+  return advisoryOnly ? 'attention' : 'blocked';
+}
+
+function summarize(workflows: InfomaniakWorkflowItem[]) {
+  return {
+    total: workflows.length,
+    ready: workflows.filter((workflow) => workflow.status === 'ready').length,
+    attention: workflows.filter((workflow) => workflow.status === 'attention')
+      .length,
+    blocked: workflows.filter((workflow) => workflow.status === 'blocked')
+      .length,
+  };
+}
+
+export function buildInfomaniakWorkflows(
+  input: BuildInfomaniakWorkflowInput,
+): InfomaniakWorkflowResult {
+  const server = input.servers.find(
+    (candidate) => candidate.name === 'infomaniak',
+  );
+  const preset = input.presets.find(
+    (candidate) => candidate.name === 'infomaniak',
+  );
+  const permission = server?.permission;
+  const skillInstalled = fs.existsSync(input.skillPath);
+  const presetInstalled = !!server || !!preset?.installed;
+  const kdriveReady = KDRIVE_KEYS.every((key) => hasEnv(server, key));
+  const davReady = DAV_KEYS.every((key) => hasEnv(server, key));
+  const mailReady = MAIL_KEYS.every((key) => hasEnv(server, key));
+  const readAllowed =
+    !!permission &&
+    permission.allowedActions.some(
+      (action) =>
+        action === '*' || action.includes('read') || action === 'tools.expose',
+    );
+  const writesApprovalGated = !!permission?.requiresApproval;
+
+  const checks: InfomaniakWorkflowCheck[] = [
+    {
+      id: 'preset-installed',
+      label: 'Infomaniak MCP preset',
+      ok: presetInstalled,
+      severity: 'required',
+      detail: presetInstalled
+        ? 'Infomaniak kSuite MCP server is installed'
+        : 'Infomaniak kSuite MCP server is not installed',
+      hint: 'Install the Infomaniak kSuite preset from MCP Servers',
+    },
+    {
+      id: 'kdrive-credentials',
+      label: 'kDrive credentials',
+      ok: kdriveReady,
+      severity: 'required',
+      detail: kdriveReady
+        ? 'INFOMANIAK_TOKEN and KDRIVE_ID are configured'
+        : 'INFOMANIAK_TOKEN or KDRIVE_ID is missing',
+      hint: 'Add Infomaniak API token and kDrive ID in Credentials',
+    },
+    {
+      id: 'dav-credentials',
+      label: 'DAV credentials',
+      ok: davReady,
+      severity: 'advisory',
+      detail: davReady
+        ? 'DAV credentials are configured for contacts and calendars'
+        : 'DAV credentials are missing',
+      hint: 'Add DAV_USER and DAV_PASSWORD to enable contact/calendar workflows',
+    },
+    {
+      id: 'mail-credentials',
+      label: 'Mail credentials',
+      ok: mailReady,
+      severity: 'advisory',
+      detail: mailReady
+        ? 'Mail credentials are configured'
+        : 'Mail credentials are missing',
+      hint: 'Add MAIL_USER and MAIL_PASSWORD to use mail-backed document workflows',
+    },
+    {
+      id: 'connector-permission',
+      label: 'Connector permission',
+      ok: readAllowed,
+      severity: 'required',
+      detail: readAllowed
+        ? 'Read/tool exposure actions are allowed for the connector scope'
+        : 'Connector read/tool exposure actions are not allowed',
+      hint: 'Allow *.read and tools.expose for the Infomaniak connector',
+    },
+    {
+      id: 'write-approval',
+      label: 'Write approval gate',
+      ok: writesApprovalGated,
+      severity: 'required',
+      detail: writesApprovalGated
+        ? 'Write-capable workflows require approval'
+        : 'Write-capable workflows are not approval gated',
+      hint: 'Keep requiresApproval enabled for upload, share, delete, and outbound mail actions',
+    },
+    {
+      id: 'skill-installed',
+      label: 'Agent skill',
+      ok: skillInstalled,
+      severity: 'advisory',
+      detail: skillInstalled
+        ? 'infomaniak-ksuite skill is available to agents'
+        : 'infomaniak-ksuite skill is missing',
+      hint: 'Install or restore the bundled infomaniak-ksuite skill',
+    },
+  ];
+
+  const documentReadReady = presetInstalled && kdriveReady && readAllowed;
+  const workflows: InfomaniakWorkflowItem[] = [
+    {
+      id: 'kdrive-search-read',
+      label: 'Search and summarize kDrive documents',
+      status: workflowStatus(documentReadReady),
+      detail: documentReadReady
+        ? 'Agents can find approved kDrive sources and summarize them'
+        : 'Install the preset, configure kDrive credentials, and allow read tools',
+      tools: ['mcp__infomaniak__*', 'infomaniak-ksuite'],
+      approvalRequired: false,
+    },
+    {
+      id: 'document-draft',
+      label: 'Draft reports from approved kDrive sources',
+      status: workflowStatus(documentReadReady && skillInstalled),
+      detail:
+        documentReadReady && skillInstalled
+          ? 'Document drafts can combine approved kDrive sources with report skills'
+          : 'Requires kDrive read readiness and the bundled Infomaniak skill',
+      tools: ['mcp__infomaniak__*', 'report-writer', 'docx-generation'],
+      approvalRequired: false,
+    },
+    {
+      id: 'upload-share',
+      label: 'Upload or share document deliverables',
+      status: workflowStatus(documentReadReady && writesApprovalGated),
+      detail:
+        documentReadReady && writesApprovalGated
+          ? 'Write-capable kDrive actions are available behind approval'
+          : 'Requires kDrive readiness with write actions kept approval gated',
+      tools: ['mcp__infomaniak__*'],
+      approvalRequired: true,
+    },
+    {
+      id: 'dav-context',
+      label: 'Use DAV contacts and calendar context',
+      status: workflowStatus(davReady && readAllowed, true),
+      detail:
+        davReady && readAllowed
+          ? 'DAV credentials can support contact and calendar context'
+          : 'DAV-backed context is optional and currently incomplete',
+      tools: ['mcp__infomaniak__*', 'meeting-briefing'],
+      approvalRequired: false,
+    },
+    {
+      id: 'mail-context',
+      label: 'Use mail as document context',
+      status: workflowStatus(mailReady && readAllowed, true),
+      detail:
+        mailReady && readAllowed
+          ? 'Mail credentials can support inbox/document context workflows'
+          : 'Mail-backed document context is optional and currently incomplete',
+      tools: ['mcp__infomaniak__*', 'email-assistant'],
+      approvalRequired: false,
+    },
+  ];
+
+  const summary = summarize(workflows);
+  return {
+    status:
+      summary.blocked > 0
+        ? 'blocked'
+        : summary.attention > 0
+          ? 'attention'
+          : 'ready',
+    generatedAt: (input.now || new Date()).toISOString(),
+    summary,
+    checks,
+    workflows,
+  };
+}
+
+export function infomaniakSkillPath(projectRoot = process.cwd()): string {
+  return path.join(
+    projectRoot,
+    'container',
+    'skills',
+    'infomaniak-ksuite',
+    'SKILL.md',
+  );
+}


### PR DESCRIPTION
## Summary
- add Infomaniak workflow readiness service for kDrive document search/read, report drafting, approval-gated upload/share, and optional DAV/mail context
- expose readiness from /api/mcp/infomaniak-workflows and show it on the MCP dashboard
- include mock dashboard data and README documentation

Fixes #41

## Verification
- rtk mise exec node@22 -- npx vitest run src/infomaniak-workflows.test.ts src/connector-permissions.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/app.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/mcp/infomaniak-workflows