### PR TITLE
Add calendar connector workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ credential surface for deployments that provide a compatible MCP server.
 The MCP dashboard also reports Infomaniak document workflow readiness, covering
 kDrive search/read, report drafting from approved sources, approval-gated
 uploads/sharing, and optional DAV/mail context.
+Calendar workflow readiness is also shown there for Google Calendar and
+Infomaniak DAV: agenda review, availability checks, meeting briefings,
+approval-gated scheduling changes, and follow-up reminders.
 
 ### Security
 

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2097,6 +2097,96 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       ],
     };
   }
+  if (pathname === '/mcp/calendar-workflows') {
+    return {
+      status: 'attention',
+      generatedAt: iso(0),
+      summary: { total: 5, ready: 4, attention: 1, blocked: 0 },
+      checks: [
+        {
+          id: 'calendar-provider',
+          label: 'Calendar provider',
+          ok: true,
+          severity: 'required',
+          detail: 'Google Calendar and Infomaniak DAV ready for calendar reads',
+        },
+        {
+          id: 'google-calendar',
+          label: 'Google Calendar',
+          ok: true,
+          severity: 'advisory',
+          detail:
+            'Google Workspace calendar credentials and read permissions are ready',
+        },
+        {
+          id: 'infomaniak-dav',
+          label: 'Infomaniak DAV calendar',
+          ok: true,
+          severity: 'advisory',
+          detail: 'Infomaniak DAV credentials and read permissions are ready',
+        },
+        {
+          id: 'write-approval',
+          label: 'Calendar write approval',
+          ok: true,
+          severity: 'required',
+          detail: 'Calendar writes are approval gated',
+        },
+        {
+          id: 'meeting-briefing-skill',
+          label: 'Meeting briefing skill',
+          ok: false,
+          severity: 'advisory',
+          detail: 'meeting-briefing skill is missing in this mock scenario',
+          hint: 'Restore the bundled meeting-briefing skill for richer meeting prep',
+        },
+      ],
+      workflows: [
+        {
+          id: 'agenda-review',
+          label: 'Review upcoming agenda',
+          status: 'ready',
+          detail:
+            'Agents can list upcoming calendar events and summarize the day',
+          providers: ['Google Calendar', 'Infomaniak DAV'],
+          approvalRequired: false,
+        },
+        {
+          id: 'availability',
+          label: 'Check availability and conflicts',
+          status: 'ready',
+          detail: 'Agents can inspect availability and identify conflicts',
+          providers: ['Google Calendar', 'Infomaniak DAV'],
+          approvalRequired: false,
+        },
+        {
+          id: 'meeting-briefing',
+          label: 'Prepare meeting briefings',
+          status: 'attention',
+          detail:
+            'Meeting briefings need calendar read access and the briefing skill',
+          providers: ['Google Calendar', 'Infomaniak DAV'],
+          approvalRequired: false,
+        },
+        {
+          id: 'schedule-change',
+          label: 'Create, update, or delete events',
+          status: 'ready',
+          detail: 'Calendar mutations are available behind explicit approval',
+          providers: ['Google Calendar', 'Infomaniak DAV'],
+          approvalRequired: true,
+        },
+        {
+          id: 'follow-up-reminders',
+          label: 'Create follow-up reminders',
+          status: 'ready',
+          detail: 'Agents can propose reminders after approved meeting context',
+          providers: ['Google Calendar', 'Infomaniak DAV'],
+          approvalRequired: true,
+        },
+      ],
+    };
+  }
   if (pathname === '/providers') return providers();
   if (pathname === '/memory') {
     return [

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -2589,10 +2589,12 @@ window.deleteCredential = async (key, btnEl) => {
 
 // MCP Servers
 async function renderMcp(el) {
-  const [health, presets, infomaniakWorkflows] = await Promise.all([
+  const [health, presets, infomaniakWorkflows, calendarWorkflows] =
+    await Promise.all([
     api('/mcp/health'),
     api('/mcp/presets').catch(() => []),
     api('/mcp/infomaniak-workflows').catch(() => null),
+    api('/mcp/calendar-workflows').catch(() => null),
   ]);
   const servers = health.servers || [];
   el.innerHTML = `
@@ -2660,6 +2662,50 @@ async function renderMcp(el) {
       </div>
       <div style="display:grid;gap:6px">
         ${infomaniakWorkflows.checks
+          .map(
+            (check) => `
+          <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;font-size:12px;padding:7px 8px;border:1px solid var(--border);border-radius:var(--radius-sm)">
+            <div>
+              <strong style="color:var(--text)">${esc(check.label)}</strong>
+              <div style="color:var(--text-muted);margin-top:2px">${esc(check.detail)}</div>
+              ${check.hint && !check.ok ? `<div style="color:var(--warning);margin-top:2px">${esc(check.hint)}</div>` : ''}
+            </div>
+            <span class="badge ${check.ok ? 'badge-success' : check.severity === 'required' ? 'badge-error' : 'badge-warning'}">${check.ok ? 'OK' : check.severity === 'required' ? 'Block' : 'Warn'}</span>
+          </div>`,
+          )
+          .join('')}
+      </div>
+    </div>`
+        : ''
+    }
+    ${
+      calendarWorkflows
+        ? `<div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:10px">
+        <div>
+          <div class="card-title" style="margin:0">Calendar Workflows</div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">Agenda review, availability, meeting briefings, scheduling, and follow-up reminders across configured calendar connectors.</div>
+        </div>
+        <span class="badge ${calendarWorkflows.status === 'ready' ? 'badge-success' : calendarWorkflows.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(calendarWorkflows.status)}</span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:8px;margin-bottom:12px">
+        ${calendarWorkflows.workflows
+          .map(
+            (workflow) => `
+          <div style="padding:9px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+            <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+              <strong style="font-size:12px;color:var(--text)">${esc(workflow.label)}</strong>
+              <span class="badge ${workflow.status === 'ready' ? 'badge-success' : workflow.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(workflow.status)}</span>
+            </div>
+            <div style="font-size:11px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(workflow.detail)}</div>
+            ${workflow.providers?.length ? `<div style="font-size:11px;color:var(--text-muted);margin-top:5px">${workflow.providers.map((provider) => esc(provider)).join(', ')}</div>` : ''}
+            ${workflow.approvalRequired ? '<div style="font-size:11px;color:var(--warning);margin-top:5px">Requires explicit approval before calendar changes.</div>' : ''}
+          </div>`,
+          )
+          .join('')}
+      </div>
+      <div style="display:grid;gap:6px">
+        ${calendarWorkflows.checks
           .map(
             (check) => `
           <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;font-size:12px;padding:7px 8px;border:1px solid var(--border);border-radius:var(--radius-sm)">

--- a/src/admin/routes/mcp.ts
+++ b/src/admin/routes/mcp.ts
@@ -13,6 +13,11 @@ import {
   buildInfomaniakWorkflows,
   infomaniakSkillPath,
 } from '../../infomaniak-workflows.js';
+import {
+  buildCalendarWorkflows,
+  calendarSkillPath,
+  meetingBriefingSkillPath,
+} from '../../calendar-workflows.js';
 
 const router = Router();
 const PROJECT_ROOT = process.cwd();
@@ -187,6 +192,17 @@ router.get('/infomaniak-workflows', (_req: Request, res: Response) => {
         installed: configured.has(preset.name),
       })),
       skillPath: infomaniakSkillPath(PROJECT_ROOT),
+    }),
+  );
+});
+
+router.get('/calendar-workflows', (_req: Request, res: Response) => {
+  const status = getStatus();
+  res.json(
+    buildCalendarWorkflows({
+      servers: status.servers,
+      calendarSkillPath: calendarSkillPath(PROJECT_ROOT),
+      meetingSkillPath: meetingBriefingSkillPath(PROJECT_ROOT),
     }),
   );
 });

--- a/src/calendar-workflows.test.ts
+++ b/src/calendar-workflows.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildCalendarWorkflows } from './calendar-workflows.js';
+
+function skillPath(name: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-calendar-'));
+  const file = path.join(root, 'container', 'skills', name, 'SKILL.md');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `# ${name}\n`);
+  return file;
+}
+
+const googleServer = {
+  name: 'google-workspace',
+  allEnvSet: true,
+  envStatus: [
+    { key: 'GOOGLE_OAUTH_CLIENT_ID', isSet: true },
+    { key: 'GOOGLE_OAUTH_CLIENT_SECRET', isSet: true },
+    { key: 'GOOGLE_REFRESH_TOKEN', isSet: true },
+  ],
+  permission: {
+    connectorId: 'google-workspace',
+    scope: 'main' as const,
+    allowedActions: ['calendar.read', 'tools.expose'],
+    requiresApproval: true,
+    groups: [],
+    agents: [],
+    createdAt: '2026-06-13T10:00:00.000Z',
+    updatedAt: '2026-06-13T10:00:00.000Z',
+  },
+};
+
+describe('calendar workflows', () => {
+  it('reports calendar workflows ready with a configured provider and skills', () => {
+    const result = buildCalendarWorkflows({
+      servers: [googleServer],
+      calendarSkillPath: skillPath('calendar-assistant'),
+      meetingSkillPath: skillPath('meeting-briefing'),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('ready');
+    expect(result.summary.ready).toBe(result.summary.total);
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({
+        id: 'schedule-change',
+        status: 'ready',
+        approvalRequired: true,
+      }),
+    );
+  });
+
+  it('blocks calendar mutation workflows when approval is disabled', () => {
+    const result = buildCalendarWorkflows({
+      servers: [
+        {
+          ...googleServer,
+          permission: {
+            ...googleServer.permission,
+            requiresApproval: false,
+          },
+        },
+      ],
+      calendarSkillPath: skillPath('calendar-assistant'),
+      meetingSkillPath: skillPath('meeting-briefing'),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'write-approval',
+        ok: false,
+        severity: 'required',
+      }),
+    );
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({ id: 'schedule-change', status: 'blocked' }),
+    );
+  });
+});

--- a/src/calendar-workflows.ts
+++ b/src/calendar-workflows.ts
@@ -1,0 +1,282 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { ConnectorPermission } from './connector-permissions.js';
+
+export type CalendarWorkflowStatus = 'ready' | 'attention' | 'blocked';
+export type CalendarWorkflowSeverity = 'required' | 'advisory';
+
+export interface CalendarWorkflowServer {
+  name: string;
+  allEnvSet?: boolean;
+  envStatus?: Array<{ key: string; isSet: boolean }>;
+  permission?: ConnectorPermission;
+}
+
+export interface CalendarWorkflowItem {
+  id: string;
+  label: string;
+  status: CalendarWorkflowStatus;
+  detail: string;
+  providers: string[];
+  approvalRequired: boolean;
+}
+
+export interface CalendarWorkflowCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  severity: CalendarWorkflowSeverity;
+  detail: string;
+  hint?: string;
+}
+
+export interface CalendarWorkflowResult {
+  status: CalendarWorkflowStatus;
+  generatedAt: string;
+  summary: {
+    total: number;
+    ready: number;
+    attention: number;
+    blocked: number;
+  };
+  checks: CalendarWorkflowCheck[];
+  workflows: CalendarWorkflowItem[];
+}
+
+export interface BuildCalendarWorkflowInput {
+  servers: CalendarWorkflowServer[];
+  calendarSkillPath: string;
+  meetingSkillPath: string;
+  now?: Date;
+}
+
+const GOOGLE_KEYS = [
+  'GOOGLE_OAUTH_CLIENT_ID',
+  'GOOGLE_OAUTH_CLIENT_SECRET',
+  'GOOGLE_REFRESH_TOKEN',
+];
+const INFOMANIAK_DAV_KEYS = ['DAV_USER', 'DAV_PASSWORD'];
+
+function hasEnv(server: CalendarWorkflowServer | undefined, key: string) {
+  return !!server?.envStatus?.some(
+    (status) => status.key === key && status.isSet,
+  );
+}
+
+function hasReadPermission(server: CalendarWorkflowServer | undefined) {
+  const actions = server?.permission?.allowedActions || [];
+  return actions.some(
+    (action) =>
+      action === '*' || action.includes('read') || action === 'tools.expose',
+  );
+}
+
+function approvalGated(server: CalendarWorkflowServer | undefined) {
+  return !server || !!server.permission?.requiresApproval;
+}
+
+function summarize(workflows: CalendarWorkflowItem[]) {
+  return {
+    total: workflows.length,
+    ready: workflows.filter((workflow) => workflow.status === 'ready').length,
+    attention: workflows.filter((workflow) => workflow.status === 'attention')
+      .length,
+    blocked: workflows.filter((workflow) => workflow.status === 'blocked')
+      .length,
+  };
+}
+
+function status(ok: boolean, advisoryOnly = false): CalendarWorkflowStatus {
+  if (ok) return 'ready';
+  return advisoryOnly ? 'attention' : 'blocked';
+}
+
+export function buildCalendarWorkflows(
+  input: BuildCalendarWorkflowInput,
+): CalendarWorkflowResult {
+  const google = input.servers.find(
+    (server) => server.name === 'google-workspace',
+  );
+  const infomaniak = input.servers.find(
+    (server) => server.name === 'infomaniak',
+  );
+  const googleReady =
+    !!google &&
+    GOOGLE_KEYS.every((key) => hasEnv(google, key)) &&
+    hasReadPermission(google);
+  const infomaniakDavReady =
+    !!infomaniak &&
+    INFOMANIAK_DAV_KEYS.every((key) => hasEnv(infomaniak, key)) &&
+    hasReadPermission(infomaniak);
+  const anyCalendarReadReady = googleReady || infomaniakDavReady;
+  const writeApprovalReady = approvalGated(google) && approvalGated(infomaniak);
+  const calendarSkill = fs.existsSync(input.calendarSkillPath);
+  const meetingSkill = fs.existsSync(input.meetingSkillPath);
+  const readyProviders = [
+    googleReady ? 'Google Calendar' : null,
+    infomaniakDavReady ? 'Infomaniak DAV' : null,
+  ].filter((provider): provider is string => !!provider);
+
+  const checks: CalendarWorkflowCheck[] = [
+    {
+      id: 'calendar-provider',
+      label: 'Calendar provider',
+      ok: anyCalendarReadReady,
+      severity: 'required',
+      detail: anyCalendarReadReady
+        ? `${readyProviders.join(' and ')} ready for calendar reads`
+        : 'No calendar provider is ready',
+      hint: 'Configure Google Workspace calendar credentials or Infomaniak DAV credentials with read tool exposure',
+    },
+    {
+      id: 'google-calendar',
+      label: 'Google Calendar',
+      ok: googleReady,
+      severity: 'advisory',
+      detail: googleReady
+        ? 'Google Workspace calendar credentials and read permissions are ready'
+        : 'Google Workspace calendar is not ready',
+      hint: 'Configure Google OAuth credentials and the google-workspace MCP server',
+    },
+    {
+      id: 'infomaniak-dav',
+      label: 'Infomaniak DAV calendar',
+      ok: infomaniakDavReady,
+      severity: 'advisory',
+      detail: infomaniakDavReady
+        ? 'Infomaniak DAV credentials and read permissions are ready'
+        : 'Infomaniak DAV calendar is not ready',
+      hint: 'Configure DAV_USER and DAV_PASSWORD on the Infomaniak MCP preset',
+    },
+    {
+      id: 'write-approval',
+      label: 'Calendar write approval',
+      ok: writeApprovalReady,
+      severity: 'required',
+      detail: writeApprovalReady
+        ? 'Calendar writes are approval gated'
+        : 'At least one calendar connector allows writes without approval',
+      hint: 'Keep requiresApproval enabled for create, update, delete, invite, and reschedule actions',
+    },
+    {
+      id: 'calendar-skill',
+      label: 'Calendar assistant skill',
+      ok: calendarSkill,
+      severity: 'required',
+      detail: calendarSkill
+        ? 'calendar-assistant skill is available'
+        : 'calendar-assistant skill is missing',
+      hint: 'Restore the bundled calendar-assistant skill',
+    },
+    {
+      id: 'meeting-briefing-skill',
+      label: 'Meeting briefing skill',
+      ok: meetingSkill,
+      severity: 'advisory',
+      detail: meetingSkill
+        ? 'meeting-briefing skill is available'
+        : 'meeting-briefing skill is missing',
+      hint: 'Restore the bundled meeting-briefing skill for richer meeting prep',
+    },
+  ];
+
+  const workflows: CalendarWorkflowItem[] = [
+    {
+      id: 'agenda-review',
+      label: 'Review upcoming agenda',
+      status: status(anyCalendarReadReady && calendarSkill),
+      detail:
+        anyCalendarReadReady && calendarSkill
+          ? 'Agents can list upcoming calendar events and summarize the day'
+          : 'Requires a ready calendar provider and calendar skill',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'availability',
+      label: 'Check availability and conflicts',
+      status: status(anyCalendarReadReady && calendarSkill),
+      detail:
+        anyCalendarReadReady && calendarSkill
+          ? 'Agents can inspect availability and identify conflicts'
+          : 'Requires calendar read access',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'meeting-briefing',
+      label: 'Prepare meeting briefings',
+      status: status(
+        anyCalendarReadReady && calendarSkill && meetingSkill,
+        true,
+      ),
+      detail:
+        anyCalendarReadReady && calendarSkill && meetingSkill
+          ? 'Agents can combine calendar events with memory, chat, and documents'
+          : 'Meeting briefings need calendar read access and the briefing skill',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'schedule-change',
+      label: 'Create, update, or delete events',
+      status: status(
+        anyCalendarReadReady && calendarSkill && writeApprovalReady,
+      ),
+      detail:
+        anyCalendarReadReady && calendarSkill && writeApprovalReady
+          ? 'Calendar mutations are available behind explicit approval'
+          : 'Calendar write workflows require readiness plus approval gates',
+      providers: readyProviders,
+      approvalRequired: true,
+    },
+    {
+      id: 'follow-up-reminders',
+      label: 'Create follow-up reminders',
+      status: status(
+        anyCalendarReadReady && calendarSkill && writeApprovalReady,
+      ),
+      detail:
+        anyCalendarReadReady && calendarSkill && writeApprovalReady
+          ? 'Agents can propose reminders after approved meeting context'
+          : 'Reminder creation requires calendar readiness and approval gates',
+      providers: readyProviders,
+      approvalRequired: true,
+    },
+  ];
+
+  const summary = summarize(workflows);
+  return {
+    status:
+      summary.blocked > 0
+        ? 'blocked'
+        : summary.attention > 0
+          ? 'attention'
+          : 'ready',
+    generatedAt: (input.now || new Date()).toISOString(),
+    summary,
+    checks,
+    workflows,
+  };
+}
+
+export function calendarSkillPath(projectRoot = process.cwd()): string {
+  return path.join(
+    projectRoot,
+    'container',
+    'skills',
+    'calendar-assistant',
+    'SKILL.md',
+  );
+}
+
+export function meetingBriefingSkillPath(projectRoot = process.cwd()): string {
+  return path.join(
+    projectRoot,
+    'container',
+    'skills',
+    'meeting-briefing',
+    'SKILL.md',
+  );
+}


### PR DESCRIPTION
## Summary
- add calendar workflow readiness service for Google Calendar and Infomaniak DAV providers
- expose /api/mcp/calendar-workflows and show agenda, availability, meeting briefing, scheduling, and reminder readiness in MCP dashboard
- include mock dashboard data and README documentation

Fixes #40

## Verification
- rtk mise exec node@22 -- npx vitest run src/calendar-workflows.test.ts src/infomaniak-workflows.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/app.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/mcp/calendar-workflows