### PR TITLE
Add email connector workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ uploads/sharing, and optional DAV/mail context.
 Calendar workflow readiness is also shown there for Google Calendar and
 Infomaniak DAV: agenda review, availability checks, meeting briefings,
 approval-gated scheduling changes, and follow-up reminders.
+Email workflow readiness covers Gmail and Infomaniak Mail: narrow search,
+thread summaries, inbox triage, reply drafts, approval-gated sending, and
+mailbox cleanup.
 
 ### Security
 

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2187,6 +2187,97 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       ],
     };
   }
+  if (pathname === '/mcp/email-workflows') {
+    return {
+      status: 'attention',
+      generatedAt: iso(0),
+      summary: { total: 5, ready: 4, attention: 1, blocked: 0 },
+      checks: [
+        {
+          id: 'email-provider',
+          label: 'Email provider',
+          ok: true,
+          severity: 'required',
+          detail: 'Gmail and Infomaniak Mail ready for email reads',
+        },
+        {
+          id: 'gmail',
+          label: 'Gmail',
+          ok: true,
+          severity: 'advisory',
+          detail:
+            'Google Workspace Gmail credentials and read permissions are ready',
+        },
+        {
+          id: 'infomaniak-mail',
+          label: 'Infomaniak Mail',
+          ok: true,
+          severity: 'advisory',
+          detail: 'Infomaniak mail credentials and read permissions are ready',
+        },
+        {
+          id: 'write-approval',
+          label: 'Email write approval',
+          ok: true,
+          severity: 'required',
+          detail: 'Email sends and mailbox mutations are approval gated',
+        },
+        {
+          id: 'inbox-triage-skill',
+          label: 'Inbox triage skill',
+          ok: false,
+          severity: 'advisory',
+          detail: 'inbox-triage skill is missing in this mock scenario',
+          hint: 'Restore the bundled inbox-triage skill for cleanup workflows',
+        },
+      ],
+      workflows: [
+        {
+          id: 'mail-search-summary',
+          label: 'Search and summarize mail',
+          status: 'ready',
+          detail:
+            'Agents can search mail narrowly and summarize relevant threads',
+          providers: ['Gmail', 'Infomaniak Mail'],
+          approvalRequired: false,
+        },
+        {
+          id: 'inbox-triage',
+          label: 'Triage inboxes',
+          status: 'attention',
+          detail:
+            'Inbox triage needs email read access and the inbox-triage skill',
+          providers: ['Gmail', 'Infomaniak Mail'],
+          approvalRequired: false,
+        },
+        {
+          id: 'reply-draft',
+          label: 'Draft replies and follow-ups',
+          status: 'ready',
+          detail: 'Agents can draft replies without sending them',
+          providers: ['Gmail', 'Infomaniak Mail'],
+          approvalRequired: false,
+        },
+        {
+          id: 'send-reply',
+          label: 'Send or reply to email',
+          status: 'ready',
+          detail: 'Outbound mail is available behind explicit approval',
+          providers: ['Gmail', 'Infomaniak Mail'],
+          approvalRequired: true,
+        },
+        {
+          id: 'mailbox-mutation',
+          label: 'Archive, label, delete, or move messages',
+          status: 'ready',
+          detail:
+            'Mailbox cleanup actions are available behind explicit approval',
+          providers: ['Gmail', 'Infomaniak Mail'],
+          approvalRequired: true,
+        },
+      ],
+    };
+  }
   if (pathname === '/providers') return providers();
   if (pathname === '/memory') {
     return [

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -2589,13 +2589,14 @@ window.deleteCredential = async (key, btnEl) => {
 
 // MCP Servers
 async function renderMcp(el) {
-  const [health, presets, infomaniakWorkflows, calendarWorkflows] =
+  const [health, presets, infomaniakWorkflows, calendarWorkflows, emailWorkflows] =
     await Promise.all([
-    api('/mcp/health'),
-    api('/mcp/presets').catch(() => []),
-    api('/mcp/infomaniak-workflows').catch(() => null),
-    api('/mcp/calendar-workflows').catch(() => null),
-  ]);
+      api('/mcp/health'),
+      api('/mcp/presets').catch(() => []),
+      api('/mcp/infomaniak-workflows').catch(() => null),
+      api('/mcp/calendar-workflows').catch(() => null),
+      api('/mcp/email-workflows').catch(() => null),
+    ]);
   const servers = health.servers || [];
   el.innerHTML = `
     <div class="page-header"><h2>MCP Servers</h2>
@@ -2706,6 +2707,50 @@ async function renderMcp(el) {
       </div>
       <div style="display:grid;gap:6px">
         ${calendarWorkflows.checks
+          .map(
+            (check) => `
+          <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;font-size:12px;padding:7px 8px;border:1px solid var(--border);border-radius:var(--radius-sm)">
+            <div>
+              <strong style="color:var(--text)">${esc(check.label)}</strong>
+              <div style="color:var(--text-muted);margin-top:2px">${esc(check.detail)}</div>
+              ${check.hint && !check.ok ? `<div style="color:var(--warning);margin-top:2px">${esc(check.hint)}</div>` : ''}
+            </div>
+            <span class="badge ${check.ok ? 'badge-success' : check.severity === 'required' ? 'badge-error' : 'badge-warning'}">${check.ok ? 'OK' : check.severity === 'required' ? 'Block' : 'Warn'}</span>
+          </div>`,
+          )
+          .join('')}
+      </div>
+    </div>`
+        : ''
+    }
+    ${
+      emailWorkflows
+        ? `<div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:10px">
+        <div>
+          <div class="card-title" style="margin:0">Email Workflows</div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:2px">Mail search, thread summaries, inbox triage, reply drafts, approved sending, and mailbox cleanup.</div>
+        </div>
+        <span class="badge ${emailWorkflows.status === 'ready' ? 'badge-success' : emailWorkflows.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(emailWorkflows.status)}</span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:8px;margin-bottom:12px">
+        ${emailWorkflows.workflows
+          .map(
+            (workflow) => `
+          <div style="padding:9px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--surface)">
+            <div style="display:flex;justify-content:space-between;gap:8px;align-items:center">
+              <strong style="font-size:12px;color:var(--text)">${esc(workflow.label)}</strong>
+              <span class="badge ${workflow.status === 'ready' ? 'badge-success' : workflow.status === 'blocked' ? 'badge-error' : 'badge-warning'}">${esc(workflow.status)}</span>
+            </div>
+            <div style="font-size:11px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(workflow.detail)}</div>
+            ${workflow.providers?.length ? `<div style="font-size:11px;color:var(--text-muted);margin-top:5px">${workflow.providers.map((provider) => esc(provider)).join(', ')}</div>` : ''}
+            ${workflow.approvalRequired ? '<div style="font-size:11px;color:var(--warning);margin-top:5px">Requires explicit approval before sending or mailbox changes.</div>' : ''}
+          </div>`,
+          )
+          .join('')}
+      </div>
+      <div style="display:grid;gap:6px">
+        ${emailWorkflows.checks
           .map(
             (check) => `
           <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;font-size:12px;padding:7px 8px;border:1px solid var(--border);border-radius:var(--radius-sm)">

--- a/src/admin/routes/mcp.ts
+++ b/src/admin/routes/mcp.ts
@@ -18,6 +18,11 @@ import {
   calendarSkillPath,
   meetingBriefingSkillPath,
 } from '../../calendar-workflows.js';
+import {
+  buildEmailWorkflows,
+  emailSkillPath,
+  inboxTriageSkillPath,
+} from '../../email-workflows.js';
 
 const router = Router();
 const PROJECT_ROOT = process.cwd();
@@ -203,6 +208,17 @@ router.get('/calendar-workflows', (_req: Request, res: Response) => {
       servers: status.servers,
       calendarSkillPath: calendarSkillPath(PROJECT_ROOT),
       meetingSkillPath: meetingBriefingSkillPath(PROJECT_ROOT),
+    }),
+  );
+});
+
+router.get('/email-workflows', (_req: Request, res: Response) => {
+  const status = getStatus();
+  res.json(
+    buildEmailWorkflows({
+      servers: status.servers,
+      emailSkillPath: emailSkillPath(PROJECT_ROOT),
+      inboxTriageSkillPath: inboxTriageSkillPath(PROJECT_ROOT),
     }),
   );
 });

--- a/src/email-workflows.test.ts
+++ b/src/email-workflows.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildEmailWorkflows } from './email-workflows.js';
+
+function skillPath(name: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-email-'));
+  const file = path.join(root, 'container', 'skills', name, 'SKILL.md');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `# ${name}\n`);
+  return file;
+}
+
+const googleServer = {
+  name: 'google-workspace',
+  allEnvSet: true,
+  envStatus: [
+    { key: 'GOOGLE_OAUTH_CLIENT_ID', isSet: true },
+    { key: 'GOOGLE_OAUTH_CLIENT_SECRET', isSet: true },
+    { key: 'GOOGLE_REFRESH_TOKEN', isSet: true },
+  ],
+  permission: {
+    connectorId: 'google-workspace',
+    scope: 'main' as const,
+    allowedActions: ['mail.read', 'tools.expose'],
+    requiresApproval: true,
+    groups: [],
+    agents: [],
+    createdAt: '2026-06-13T10:00:00.000Z',
+    updatedAt: '2026-06-13T10:00:00.000Z',
+  },
+};
+
+describe('email workflows', () => {
+  it('reports email workflows ready with a configured provider and skills', () => {
+    const result = buildEmailWorkflows({
+      servers: [googleServer],
+      emailSkillPath: skillPath('email-assistant'),
+      inboxTriageSkillPath: skillPath('inbox-triage'),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('ready');
+    expect(result.summary.ready).toBe(result.summary.total);
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({
+        id: 'send-reply',
+        status: 'ready',
+        approvalRequired: true,
+      }),
+    );
+  });
+
+  it('blocks outbound mail and mailbox mutation workflows when approval is disabled', () => {
+    const result = buildEmailWorkflows({
+      servers: [
+        {
+          ...googleServer,
+          permission: {
+            ...googleServer.permission,
+            requiresApproval: false,
+          },
+        },
+      ],
+      emailSkillPath: skillPath('email-assistant'),
+      inboxTriageSkillPath: skillPath('inbox-triage'),
+      now: new Date('2026-06-13T10:01:00.000Z'),
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'write-approval',
+        ok: false,
+        severity: 'required',
+      }),
+    );
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({ id: 'send-reply', status: 'blocked' }),
+    );
+    expect(result.workflows).toContainEqual(
+      expect.objectContaining({ id: 'mailbox-mutation', status: 'blocked' }),
+    );
+  });
+});

--- a/src/email-workflows.ts
+++ b/src/email-workflows.ts
@@ -1,0 +1,275 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { ConnectorPermission } from './connector-permissions.js';
+
+export type EmailWorkflowStatus = 'ready' | 'attention' | 'blocked';
+export type EmailWorkflowSeverity = 'required' | 'advisory';
+
+export interface EmailWorkflowServer {
+  name: string;
+  allEnvSet?: boolean;
+  envStatus?: Array<{ key: string; isSet: boolean }>;
+  permission?: ConnectorPermission;
+}
+
+export interface EmailWorkflowItem {
+  id: string;
+  label: string;
+  status: EmailWorkflowStatus;
+  detail: string;
+  providers: string[];
+  approvalRequired: boolean;
+}
+
+export interface EmailWorkflowCheck {
+  id: string;
+  label: string;
+  ok: boolean;
+  severity: EmailWorkflowSeverity;
+  detail: string;
+  hint?: string;
+}
+
+export interface EmailWorkflowResult {
+  status: EmailWorkflowStatus;
+  generatedAt: string;
+  summary: {
+    total: number;
+    ready: number;
+    attention: number;
+    blocked: number;
+  };
+  checks: EmailWorkflowCheck[];
+  workflows: EmailWorkflowItem[];
+}
+
+export interface BuildEmailWorkflowInput {
+  servers: EmailWorkflowServer[];
+  emailSkillPath: string;
+  inboxTriageSkillPath: string;
+  now?: Date;
+}
+
+const GOOGLE_KEYS = [
+  'GOOGLE_OAUTH_CLIENT_ID',
+  'GOOGLE_OAUTH_CLIENT_SECRET',
+  'GOOGLE_REFRESH_TOKEN',
+];
+const INFOMANIAK_MAIL_KEYS = ['MAIL_USER', 'MAIL_PASSWORD'];
+
+function hasEnv(server: EmailWorkflowServer | undefined, key: string) {
+  return !!server?.envStatus?.some(
+    (status) => status.key === key && status.isSet,
+  );
+}
+
+function hasReadPermission(server: EmailWorkflowServer | undefined) {
+  const actions = server?.permission?.allowedActions || [];
+  return actions.some(
+    (action) =>
+      action === '*' || action.includes('read') || action === 'tools.expose',
+  );
+}
+
+function approvalGated(server: EmailWorkflowServer | undefined) {
+  return !server || !!server.permission?.requiresApproval;
+}
+
+function status(ok: boolean, advisoryOnly = false): EmailWorkflowStatus {
+  if (ok) return 'ready';
+  return advisoryOnly ? 'attention' : 'blocked';
+}
+
+function summarize(workflows: EmailWorkflowItem[]) {
+  return {
+    total: workflows.length,
+    ready: workflows.filter((workflow) => workflow.status === 'ready').length,
+    attention: workflows.filter((workflow) => workflow.status === 'attention')
+      .length,
+    blocked: workflows.filter((workflow) => workflow.status === 'blocked')
+      .length,
+  };
+}
+
+export function buildEmailWorkflows(
+  input: BuildEmailWorkflowInput,
+): EmailWorkflowResult {
+  const google = input.servers.find(
+    (server) => server.name === 'google-workspace',
+  );
+  const infomaniak = input.servers.find(
+    (server) => server.name === 'infomaniak',
+  );
+  const googleReady =
+    !!google &&
+    GOOGLE_KEYS.every((key) => hasEnv(google, key)) &&
+    hasReadPermission(google);
+  const infomaniakReady =
+    !!infomaniak &&
+    INFOMANIAK_MAIL_KEYS.every((key) => hasEnv(infomaniak, key)) &&
+    hasReadPermission(infomaniak);
+  const anyEmailReadReady = googleReady || infomaniakReady;
+  const writeApprovalReady = approvalGated(google) && approvalGated(infomaniak);
+  const emailSkill = fs.existsSync(input.emailSkillPath);
+  const inboxSkill = fs.existsSync(input.inboxTriageSkillPath);
+  const readyProviders = [
+    googleReady ? 'Gmail' : null,
+    infomaniakReady ? 'Infomaniak Mail' : null,
+  ].filter((provider): provider is string => !!provider);
+
+  const checks: EmailWorkflowCheck[] = [
+    {
+      id: 'email-provider',
+      label: 'Email provider',
+      ok: anyEmailReadReady,
+      severity: 'required',
+      detail: anyEmailReadReady
+        ? `${readyProviders.join(' and ')} ready for email reads`
+        : 'No email provider is ready',
+      hint: 'Configure Google Workspace Gmail credentials or Infomaniak mail credentials with read tool exposure',
+    },
+    {
+      id: 'gmail',
+      label: 'Gmail',
+      ok: googleReady,
+      severity: 'advisory',
+      detail: googleReady
+        ? 'Google Workspace Gmail credentials and read permissions are ready'
+        : 'Google Workspace Gmail is not ready',
+      hint: 'Configure Google OAuth credentials and the google-workspace MCP server',
+    },
+    {
+      id: 'infomaniak-mail',
+      label: 'Infomaniak Mail',
+      ok: infomaniakReady,
+      severity: 'advisory',
+      detail: infomaniakReady
+        ? 'Infomaniak mail credentials and read permissions are ready'
+        : 'Infomaniak mail is not ready',
+      hint: 'Configure MAIL_USER and MAIL_PASSWORD on the Infomaniak MCP preset',
+    },
+    {
+      id: 'write-approval',
+      label: 'Email write approval',
+      ok: writeApprovalReady,
+      severity: 'required',
+      detail: writeApprovalReady
+        ? 'Email sends and mailbox mutations are approval gated'
+        : 'At least one email connector allows writes without approval',
+      hint: 'Keep requiresApproval enabled for send, reply, forward, delete, archive, and label actions',
+    },
+    {
+      id: 'email-skill',
+      label: 'Email assistant skill',
+      ok: emailSkill,
+      severity: 'required',
+      detail: emailSkill
+        ? 'email-assistant skill is available'
+        : 'email-assistant skill is missing',
+      hint: 'Restore the bundled email-assistant skill',
+    },
+    {
+      id: 'inbox-triage-skill',
+      label: 'Inbox triage skill',
+      ok: inboxSkill,
+      severity: 'advisory',
+      detail: inboxSkill
+        ? 'inbox-triage skill is available'
+        : 'inbox-triage skill is missing',
+      hint: 'Restore the bundled inbox-triage skill for cleanup workflows',
+    },
+  ];
+
+  const workflows: EmailWorkflowItem[] = [
+    {
+      id: 'mail-search-summary',
+      label: 'Search and summarize mail',
+      status: status(anyEmailReadReady && emailSkill),
+      detail:
+        anyEmailReadReady && emailSkill
+          ? 'Agents can search mail narrowly and summarize relevant threads'
+          : 'Requires a ready email provider and email assistant skill',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'inbox-triage',
+      label: 'Triage inboxes',
+      status: status(anyEmailReadReady && emailSkill && inboxSkill, true),
+      detail:
+        anyEmailReadReady && emailSkill && inboxSkill
+          ? 'Agents can group mail into urgent, waiting, FYI, reply-needed, and follow-up buckets'
+          : 'Inbox triage needs email read access and the inbox-triage skill',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'reply-draft',
+      label: 'Draft replies and follow-ups',
+      status: status(anyEmailReadReady && emailSkill),
+      detail:
+        anyEmailReadReady && emailSkill
+          ? 'Agents can draft replies without sending them'
+          : 'Requires email read access and the email assistant skill',
+      providers: readyProviders,
+      approvalRequired: false,
+    },
+    {
+      id: 'send-reply',
+      label: 'Send or reply to email',
+      status: status(anyEmailReadReady && emailSkill && writeApprovalReady),
+      detail:
+        anyEmailReadReady && emailSkill && writeApprovalReady
+          ? 'Outbound mail is available behind explicit approval'
+          : 'Sending requires email readiness and approval gates',
+      providers: readyProviders,
+      approvalRequired: true,
+    },
+    {
+      id: 'mailbox-mutation',
+      label: 'Archive, label, delete, or move messages',
+      status: status(anyEmailReadReady && inboxSkill && writeApprovalReady),
+      detail:
+        anyEmailReadReady && inboxSkill && writeApprovalReady
+          ? 'Mailbox cleanup actions are available behind explicit approval'
+          : 'Mailbox mutation needs inbox triage readiness and approval gates',
+      providers: readyProviders,
+      approvalRequired: true,
+    },
+  ];
+
+  const summary = summarize(workflows);
+  return {
+    status:
+      summary.blocked > 0
+        ? 'blocked'
+        : summary.attention > 0
+          ? 'attention'
+          : 'ready',
+    generatedAt: (input.now || new Date()).toISOString(),
+    summary,
+    checks,
+    workflows,
+  };
+}
+
+export function emailSkillPath(projectRoot = process.cwd()): string {
+  return path.join(
+    projectRoot,
+    'container',
+    'skills',
+    'email-assistant',
+    'SKILL.md',
+  );
+}
+
+export function inboxTriageSkillPath(projectRoot = process.cwd()): string {
+  return path.join(
+    projectRoot,
+    'container',
+    'skills',
+    'inbox-triage',
+    'SKILL.md',
+  );
+}


### PR DESCRIPTION
## Summary
- add email workflow readiness service for Gmail and Infomaniak Mail providers
- expose /api/mcp/email-workflows and show search, triage, draft, send, and mailbox cleanup readiness in MCP dashboard
- include mock dashboard data and README documentation

Fixes #39

## Verification
- rtk mise exec node@22 -- npx vitest run src/email-workflows.test.ts src/calendar-workflows.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk node --check src/admin/public/app.js
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then curl /api/mcp/email-workflows