### PR TITLE
Add cited journal answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ success responses and do not mutate live files or services.
 ### Memory, Journal, And Skills
 
 - **Memory v2** — agents can propose structured memories with sensitivity, source, stale, and contradiction metadata; the dashboard reviews what becomes active.
-- **Journal v2** — agents can record notable events, extract daily/weekly summaries, and answer natural questions like "when was that fleet crash?" with cited events.
+- **Journal v2** — agents can record notable events, extract daily/weekly summaries, and answer natural questions like "when was that fleet crash?" with cited events and summaries.
 - **Skill Factory v2** — agents can propose provider-neutral `SKILL.md` drafts with version/provenance metadata, validation, diff review, and approval before installation into `container/skills`.
 - **Bundled Default Skills** — NanoCrab ships with generic skills for memory curation, journaling, task planning, reports, GitHub issue work, code review, release management, email assistance, browser research, documents, images, and capabilities/status.
 - **Suggested Skills** — the dashboard Skills page highlights reusable workflow candidates from recent history, such as private operations planning or dashboard design review. Suggestions become inactive drafts first and still require approval.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,7 +156,7 @@ Let the agent create skills, but never install them silently.
 Build the "when did that happen?" layer before adding heavy vector systems.
 
 - DONE: Dashboard can generate daily/weekly summaries per registered group from stored message history.
-- DONE: Notable-event extraction/search APIs store cited event records with entities, tags, confidence, source message ids, and provenance.
+- DONE: Notable-event extraction/search APIs store cited event records with entities, tags, confidence, source message ids, and provenance. Journal search now produces natural-language answers with event and summary citations.
 - Tables:
   - `journal_entries`: date, scope, summary, notable_events_json, source_message_ids, provider_profile_id.
   - `journal_events`: timestamp, title, entities, location/context, confidence, source ids, tags.

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -2624,7 +2624,30 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
   if (pathname === '/journal/search') {
     return {
       query: req.query.query || 'fleet crash',
-      answer: `${day(-1)}: Fleet crash near Kepler-442b (operations)`,
+      answer: `I found 1 matching event:\n${day(-1)}: Fleet crash near Kepler-442b in operations [1]\n\nRelated journal summaries:\n${day(-1)} daily summary also mentions: 42 messages reviewed. Notable events included a fleet crash near Kepler-442b and new orders for the evening operation. [2]`,
+      generatedAt: iso(0),
+      citations: [
+        {
+          marker: '[1]',
+          kind: 'event',
+          id: 'evt-mock-1',
+          title: 'Fleet crash near Kepler-442b',
+          source: 'journal:event:evt-mock-1',
+          timestamp: iso(90),
+          groupFolder: 'operations',
+          sourceIds: [],
+        },
+        {
+          marker: '[2]',
+          kind: 'summary',
+          id: 'journal-mock-1',
+          title: `${day(-1)} daily summary`,
+          source: 'journal:entry:journal-mock-1',
+          timestamp: iso(50),
+          groupFolder: 'operations',
+          sourceIds: [],
+        },
+      ],
       events: [
         {
           id: 'evt-mock-1',
@@ -2637,6 +2660,20 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
           tags_json: '["fleet","crash"]',
           group_folder: 'operations',
           created_at: iso(88),
+        },
+      ],
+      entries: [
+        {
+          id: 'journal-mock-1',
+          date: day(-1),
+          scope: 'daily',
+          group_folder: 'operations',
+          summary:
+            '42 messages reviewed. Notable events included a fleet crash near Kepler-442b and new orders for the evening operation.',
+          notable_events_json: '[]',
+          source_message_ids_json: '[]',
+          provider_profile_id: 'default_journal',
+          created_at: iso(50),
         },
       ],
     };

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -4257,6 +4257,14 @@ async function renderMemory(el) {
       <div class="card">
         <div class="card-title">Journal Summaries</div>
         <div style="display:flex;gap:8px;align-items:end;flex-wrap:wrap;margin-bottom:12px">
+          <div class="form-group" style="margin:0;flex:1;min-width:220px">
+            <label style="font-size:12px;color:var(--text-muted)">Ask Journal</label>
+            <input class="search-input" id="journal-answer-query" placeholder="What happened near Kepler?">
+          </div>
+          <button class="btn btn-sm btn-primary" onclick="searchJournalAnswer()">Search</button>
+        </div>
+        <div id="journal-answer-result" style="margin-bottom:14px"></div>
+        <div style="display:flex;gap:8px;align-items:end;flex-wrap:wrap;margin-bottom:12px">
           <div class="form-group" style="margin:0">
             <label style="font-size:12px;color:var(--text-muted)">Group</label>
             <select class="search-input" id="journal-summary-group" style="min-width:150px">
@@ -4367,6 +4375,29 @@ window.reviewMemoryRecord = async (id, action) => {
   } catch (e) {
     toast('Failed: ' + e.message, 'error');
   }
+};
+
+window.searchJournalAnswer = async () => {
+  const query = document.getElementById('journal-answer-query')?.value || '';
+  const target = document.getElementById('journal-answer-result');
+  if (!target) return;
+  const result = await api(
+    `/journal/search?query=${encodeURIComponent(query)}`,
+  );
+  target.innerHTML = `
+    <div style="border:1px solid var(--border);border-radius:var(--radius-sm);padding:10px;background:var(--bg)">
+      <div style="font-size:12px;color:var(--text);white-space:pre-wrap;line-height:1.45">${esc(result.answer || '')}</div>
+      ${
+        result.citations?.length
+          ? `<div style="display:flex;gap:5px;flex-wrap:wrap;margin-top:8px">${result.citations
+              .map(
+                (citation) =>
+                  `<span class="badge badge-info">${esc(citation.marker)} ${esc(citation.title || citation.source)}</span>`,
+              )
+              .join('')}</div>`
+          : ''
+      }
+    </div>`;
 };
 
 window.createJournalSummary = async () => {

--- a/src/admin/routes/journal.ts
+++ b/src/admin/routes/journal.ts
@@ -10,6 +10,7 @@ import {
   recordJournalEntry,
   recordJournalEvent,
 } from '../../journal-store.js';
+import { buildJournalAnswer } from '../../journal-answers.js';
 import { requireRole } from '../middleware.js';
 import { auditLog } from '../security.js';
 
@@ -114,31 +115,32 @@ router.get('/events', (req: Request, res: Response) => {
 router.get('/search', (req: Request, res: Response) => {
   const query = typeof req.query.query === 'string' ? req.query.query : '';
   if (!query.trim()) {
-    res.json({
-      query,
-      events: [],
-      answer: 'Ask a question to search the journal.',
-    });
+    res.json(
+      buildJournalAnswer({
+        query,
+        events: [],
+        entries: [],
+      }),
+    );
     return;
   }
+  const groupFolder =
+    typeof req.query.group === 'string' ? req.query.group : undefined;
+  const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
   const events = findJournalEvents({
     query,
-    groupFolder:
-      typeof req.query.group === 'string' ? req.query.group : undefined,
-    limit: Math.min(parseInt(req.query.limit as string) || 10, 50),
+    groupFolder,
+    limit,
   });
-  const answer = events.length
-    ? events
-        .slice(0, 5)
-        .map(
-          (event) =>
-            `${event.timestamp.slice(0, 10)}: ${event.title}${
-              event.location_context ? ` (${event.location_context})` : ''
-            }`,
-        )
-        .join('\n')
-    : 'No matching journal events found.';
-  res.json({ query, answer, events });
+  const entries = listJournalEntryRecords({
+    groupFolder,
+    limit: 10,
+  }).filter((entry) =>
+    `${entry.date} ${entry.scope} ${entry.summary}`
+      .toLowerCase()
+      .includes(query.toLowerCase()),
+  );
+  res.json(buildJournalAnswer({ query, events, entries }));
 });
 
 router.post(

--- a/src/journal-answers.test.ts
+++ b/src/journal-answers.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildJournalAnswer } from './journal-answers.js';
+import type { JournalEntryRecord, JournalEventRecord } from './types.js';
+
+const event: JournalEventRecord = {
+  id: 'evt-1',
+  timestamp: '2026-06-13T10:00:00.000Z',
+  title: 'Fleet crash near Kepler-442b',
+  entities_json: '["Kepler-442b","Scout-7"]',
+  location_context: 'operations',
+  confidence: 0.82,
+  source_ids_json: '["msg-1"]',
+  tags_json: '["fleet","crash"]',
+  group_folder: 'operations',
+  created_at: '2026-06-13T10:01:00.000Z',
+};
+
+const entry: JournalEntryRecord = {
+  id: 'journal-1',
+  date: '2026-06-13',
+  scope: 'daily',
+  group_folder: 'operations',
+  summary:
+    '42 messages reviewed. Notable events included a fleet crash near Kepler-442b and new evening operation orders.',
+  notable_events_json: '[]',
+  source_message_ids_json: '["msg-1","msg-2"]',
+  provider_profile_id: 'default_journal',
+  created_at: '2026-06-13T10:05:00.000Z',
+};
+
+describe('journal answers', () => {
+  it('answers questions with cited events and summaries', () => {
+    const result = buildJournalAnswer({
+      query: 'What happened near Kepler?',
+      events: [event],
+      entries: [entry],
+      now: new Date('2026-06-13T11:00:00.000Z'),
+    });
+
+    expect(result.answer).toContain('Fleet crash near Kepler-442b');
+    expect(result.answer).toContain('[1]');
+    expect(result.answer).toContain('daily summary also mentions');
+    expect(result.citations).toEqual([
+      expect.objectContaining({
+        marker: '[1]',
+        kind: 'event',
+        id: 'evt-1',
+        source: 'journal:event:evt-1',
+      }),
+      expect.objectContaining({
+        marker: '[2]',
+        kind: 'summary',
+        id: 'journal-1',
+        source: 'journal:entry:journal-1',
+      }),
+    ]);
+  });
+
+  it('does not fabricate answers for blank questions or missing history', () => {
+    expect(
+      buildJournalAnswer({ query: '   ', events: [], entries: [] }),
+    ).toMatchObject({
+      answer: 'Ask a question to search the journal.',
+      citations: [],
+    });
+
+    expect(
+      buildJournalAnswer({ query: 'unknown thing', events: [], entries: [] }),
+    ).toMatchObject({
+      answer: 'No matching journal history found.',
+      citations: [],
+    });
+  });
+});

--- a/src/journal-answers.ts
+++ b/src/journal-answers.ts
@@ -1,0 +1,140 @@
+import type { JournalEntryRecord, JournalEventRecord } from './types.js';
+
+export type JournalAnswerCitationKind = 'event' | 'summary';
+
+export interface JournalAnswerCitation {
+  marker: string;
+  kind: JournalAnswerCitationKind;
+  id: string;
+  title: string;
+  source: string;
+  timestamp?: string;
+  groupFolder?: string | null;
+  sourceIds: string[];
+}
+
+export interface JournalAnswerResult {
+  query: string;
+  answer: string;
+  citations: JournalAnswerCitation[];
+  events: JournalEventRecord[];
+  entries: JournalEntryRecord[];
+  generatedAt: string;
+}
+
+export interface BuildJournalAnswerInput {
+  query: string;
+  events: JournalEventRecord[];
+  entries: JournalEntryRecord[];
+  now?: Date;
+}
+
+function parseJsonArray(value: string | null | undefined): string[] {
+  try {
+    const parsed = JSON.parse(value || '[]');
+    return Array.isArray(parsed)
+      ? parsed.map((item) => String(item)).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function concise(text: string, max = 220): string {
+  const trimmed = text.replace(/\s+/g, ' ').trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}...` : trimmed;
+}
+
+function eventSentence(event: JournalEventRecord, marker: string): string {
+  const date = event.timestamp.slice(0, 10);
+  const location = event.location_context
+    ? ` in ${event.location_context}`
+    : '';
+  return `${date}: ${event.title}${location} ${marker}`;
+}
+
+function entrySentence(entry: JournalEntryRecord, marker: string): string {
+  return `${entry.date} ${entry.scope} summary also mentions: ${concise(
+    entry.summary,
+  )} ${marker}`;
+}
+
+export function buildJournalAnswer(
+  input: BuildJournalAnswerInput,
+): JournalAnswerResult {
+  const query = input.query.trim();
+  const generatedAt = (input.now || new Date()).toISOString();
+  if (!query) {
+    return {
+      query: input.query,
+      answer: 'Ask a question to search the journal.',
+      citations: [],
+      events: [],
+      entries: [],
+      generatedAt,
+    };
+  }
+
+  const events = input.events.slice(0, 5);
+  const entries = input.entries.slice(0, 3);
+  if (events.length === 0 && entries.length === 0) {
+    return {
+      query,
+      answer: 'No matching journal history found.',
+      citations: [],
+      events: [],
+      entries: [],
+      generatedAt,
+    };
+  }
+
+  const citations: JournalAnswerCitation[] = [];
+  const eventLines = events.map((event) => {
+    const marker = `[${citations.length + 1}]`;
+    citations.push({
+      marker,
+      kind: 'event',
+      id: event.id,
+      title: event.title,
+      source: `journal:event:${event.id}`,
+      timestamp: event.timestamp,
+      groupFolder: event.group_folder,
+      sourceIds: parseJsonArray(event.source_ids_json),
+    });
+    return eventSentence(event, marker);
+  });
+  const entryLines = entries.map((entry) => {
+    const marker = `[${citations.length + 1}]`;
+    citations.push({
+      marker,
+      kind: 'summary',
+      id: entry.id,
+      title: `${entry.date} ${entry.scope} summary`,
+      source: `journal:entry:${entry.id}`,
+      timestamp: entry.created_at,
+      groupFolder: entry.group_folder,
+      sourceIds: parseJsonArray(entry.source_message_ids_json),
+    });
+    return entrySentence(entry, marker);
+  });
+
+  const answer = [
+    eventLines.length
+      ? `I found ${eventLines.length} matching event${eventLines.length === 1 ? '' : 's'}:\n${eventLines.join('\n')}`
+      : '',
+    entryLines.length
+      ? `Related journal summaries:\n${entryLines.join('\n')}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return {
+    query,
+    answer,
+    citations,
+    events,
+    entries,
+    generatedAt,
+  };
+}


### PR DESCRIPTION
## Summary
- add a journal answer service that turns matching journal events and summaries into cited natural-language answers
- update /api/journal/search to return answer, citations, matching events, and matching summaries
- add Memory page Ask Journal search UI with citation chips
- update mock data and docs for cited journal answers

## Verification
- rtk mise exec node@22 -- npx vitest run src/journal-answers.test.ts src/journal-store.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- rtk mise exec node@22 -- npm run format:check
- rtk node --check src/admin/public/app.js
- MOCK_ADMIN_PORT=5180 rtk mise exec node@22 -- npm run mock:admin, then checked /api/journal/search and #/memory Ask Journal in the in-app browser

Fixes #34