### PR TITLE
Add missions and runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Optional features that can be enabled/disabled from the dashboard:
 | **GitHub Copilot** | Multi-account OAuth, assign Copilot to issues, track PRs                                |
 | **Uptime Monitor** | HTTP + file-freshness health checks with bot alerts                                     |
 | **Chat**           | Send messages to the bot from the dashboard                                             |
-| **Workflows**      | Automation workflows with triggers and actions                                          |
+| **Workflows**      | Automation workflows plus missions/runbooks with tracked operator steps                 |
 | **Wiki**           | Markdown knowledge base                                                                 |
 
 Additional plugins can be installed from git URLs via the Marketplace page, or created as personal plugins that stay local (gitignored).
@@ -161,6 +161,7 @@ success responses and do not mutate live files or services.
 - **Suggested Skills** — the dashboard Skills page highlights reusable workflow candidates from recent history, such as private operations planning or dashboard design review. Suggestions become inactive drafts first and still require approval.
 - **Skill Registry** — skills can be enabled/disabled and scoped to all agents, main-only, or channel agents. Visibility can be shared, private, or system. Agents can also call `list_skills` and `search_skills` to find skills related to a user request.
 - **Reports And Research** — agents and admins can request report jobs, review outlines in Report Studio, keep draft/export generation behind outline approval, keep delivery behind a second approval gate, download generated Markdown/HTML/DOCX/PDF artifacts, index deliverables into an Artifact Vault with retention/search/source links, run Playwright-backed research notes, and configure optional official NotebookLM Enterprise support.
+- **Missions And Runbooks** — the Workflows page can define reusable runbooks, start missions from those runbooks, and track step state (`pending`, `running`, `completed`, `blocked`, or `skipped`). Steps marked as approval-required cannot be completed without an approval reference.
 - **Unified Approvals** — risky actions such as provider fallback, repo changes, PR creation, report delivery, publishing, uploads, external messages, and tool actions flow through `/api/approvals` and the dashboard Approvals inbox. Approval records include provenance (`source`, `correlationId`, `policyDecisionId`), action/resource previews, expiry metadata, and server-side filters for status, risk, kind, requester, target type, correlation ID, and created date range. Expired pending approvals are marked `expired` and cannot be approved or denied later.
 - **Backup, Restore, And Migration** — owners can create essential or full backups, download encrypted archives, configure automatic backup cadence/retention, review manual restore steps, and check legacy NanoClaw migration readiness from the dashboard Backup page.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,7 @@ This roadmap focuses on making NanoCrab more Hermes/OpenClaw-like while keeping 
 - Artifact basics exist: agents can create/list text artifacts in the group workspace and send generated files through channel tools.
 - Provider basics exist: Claude, Codex, OpenCode, Ollama, OpenRouter, and Google are selectable with preflight checks and credential-proxy support where needed. Provider profiles now route chat, coding, automations, memory, journal, skill factory, reports, docs, and vision defaults.
 - Report jobs support source scopes, outline approval, Markdown/HTML/DOCX/PDF deliverables, artifacts, and delivery approval.
+- Personal operations now include reusable runbooks and missions with step-level status tracking; approval-required steps need an approval reference before completion.
 - Better terminal controls exist in the dashboard: named shell session id, reconnect, clear, copy transcript, and xterm output.
 - Standalone cleanup is implemented: NanoCrab is treated as its own product with NanoCrab-first code, plugins, skills, MCP names, container names, docs, and migration tooling.
 - P0 closure sweep complete: non-epic P0 issues for cockpit/approvals, provider hardening, memory/skill review surfaces, timeline/router safety, GitHub coding jobs, policy/audit/dry-run controls, connector boundaries, and first-run setup are closed. Remaining P0-labeled GitHub issues are roadmap epics with lower-priority follow-up children still open.
@@ -301,7 +302,10 @@ These rules are non-negotiable:
    - Draft, validate, diff, approve, install, and sync skills.
 7. **Reports/Documents v1**
    - MCP-backed source collection, outlines, exports, and provenance.
-8. **Provider Expansion**
+8. **Personal Operations v1** - PARTIAL
+   - DONE: reusable runbooks, missions started from runbooks, dashboard step tracking, and approval references for sensitive steps.
+   - NEXT: daily and weekly briefing jobs.
+9. **Provider Expansion**
    - DONE: OpenAI Responses API adapter with 11 tests
    - DONE: Anthropic Messages API adapter with 13 tests
    - DONE: Google Gemini API adapter with 12 tests

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -52,6 +52,7 @@ import memoryRoutes from './routes/memory.js';
 import journalRoutes from './routes/journal.js';
 import reportsRoutes from './routes/reports.js';
 import artifactsRoutes from './routes/artifacts.js';
+import missionsRoutes from './routes/missions.js';
 import researchRoutes from './routes/research.js';
 import usageRoutes from './routes/usage.js';
 import sessionsRoutes from './routes/sessions.js';
@@ -226,6 +227,7 @@ export async function initAdminServer(state: NanoCrabState): Promise<void> {
   app.use('/api/journal', requireAuth, journalRoutes);
   app.use('/api/reports', requireAuth, reportsRoutes);
   app.use('/api/artifacts', requireAuth, artifactsRoutes);
+  app.use('/api/missions', requireAuth, missionsRoutes);
   app.use('/api/research', requireAuth, researchRoutes);
   app.use('/api/usage', requireAuth, usageRoutes);
   app.use('/api/sessions', requireAuth, sessionsRoutes);

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -3384,11 +3384,115 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
         id: 'wf-daily-summary',
         name: 'Daily Casual Summary',
         enabled: true,
-        trigger: 'schedule',
-        targetGroup: 'operations',
-        lastRun: iso(80),
-        status: 'ok',
-        actions: ['Collect messages', 'Extract notable events', 'Send summary'],
+        trigger: { type: 'cron', value: '0 8 * * *' },
+        createdAt: iso(2880),
+        lastTriggered: iso(80),
+        actions: [
+          { type: 'prompt', value: 'Collect messages' },
+          { type: 'prompt', value: 'Extract notable events' },
+          {
+            type: 'message',
+            value: 'Send summary',
+            targetJid: 'tg:operations-room',
+          },
+        ],
+      },
+    ];
+  }
+  if (pathname === '/missions/runbooks') {
+    return [
+      {
+        id: 'runbook-morning-brief',
+        title: 'Morning Operations Brief',
+        description:
+          'Collect overnight signals, summarize risks, and prepare operator actions.',
+        createdAt: iso(2880),
+        updatedAt: iso(2880),
+        steps: [
+          {
+            id: 'rb-step-signals',
+            title: 'Collect signals',
+            detail: 'Review journal events, inboxes, and active automations.',
+            requiresApproval: false,
+          },
+          {
+            id: 'rb-step-draft',
+            title: 'Draft brief',
+            detail: 'Prepare concise decisions, blockers, and next moves.',
+            requiresApproval: false,
+          },
+          {
+            id: 'rb-step-send',
+            title: 'Send brief',
+            detail: 'Publish to the operations channel after review.',
+            requiresApproval: true,
+          },
+        ],
+      },
+      {
+        id: 'runbook-incident',
+        title: 'Connector Incident Review',
+        description: 'Triage connector failures and capture recovery notes.',
+        createdAt: iso(1440),
+        updatedAt: iso(120),
+        steps: [
+          {
+            id: 'rb-step-scope',
+            title: 'Scope impact',
+            detail:
+              'Identify affected connector, group, and last healthy check.',
+            requiresApproval: false,
+          },
+          {
+            id: 'rb-step-recover',
+            title: 'Apply recovery',
+            detail:
+              'Restart or change connector permissions only after approval.',
+            requiresApproval: true,
+          },
+        ],
+      },
+    ];
+  }
+  if (pathname === '/missions') {
+    return [
+      {
+        id: 'mission-saturday-brief',
+        title: 'Saturday briefing',
+        owner: 'Henrik',
+        runbookId: 'runbook-morning-brief',
+        status: 'running',
+        createdAt: iso(180),
+        updatedAt: iso(20),
+        steps: [
+          {
+            id: 'mission-step-signals',
+            title: 'Collect signals',
+            detail: 'Review journal events, inboxes, and active automations.',
+            requiresApproval: false,
+            status: 'completed',
+            note: 'Journal and artifact vault reviewed.',
+            updatedAt: iso(50),
+            completedAt: iso(50),
+          },
+          {
+            id: 'mission-step-draft',
+            title: 'Draft brief',
+            detail: 'Prepare concise decisions, blockers, and next moves.',
+            requiresApproval: false,
+            status: 'running',
+            updatedAt: iso(20),
+            startedAt: iso(20),
+          },
+          {
+            id: 'mission-step-send',
+            title: 'Send brief',
+            detail: 'Publish to the operations channel after review.',
+            requiresApproval: true,
+            status: 'pending',
+            updatedAt: iso(180),
+          },
+        ],
       },
     ];
   }

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -973,11 +973,16 @@ function approvalRiskBadge(risk) {
 function approvalQueryFromFilters() {
   const filters = window._approvalFilters || {};
   const params = new URLSearchParams();
-  ['status', 'risk', 'kind', 'requester', 'targetType', 'correlationId'].forEach(
-    (key) => {
-      if (filters[key]) params.set(key, filters[key]);
-    },
-  );
+  [
+    'status',
+    'risk',
+    'kind',
+    'requester',
+    'targetType',
+    'correlationId',
+  ].forEach((key) => {
+    if (filters[key]) params.set(key, filters[key]);
+  });
   if (filters.createdFrom)
     params.set('createdFrom', `${filters.createdFrom}T00:00:00.000Z`);
   if (filters.createdTo)
@@ -995,7 +1000,8 @@ function renderApprovalCard(approval) {
     ? `<pre class="approval-preview">${esc(approval.actionPreview)}</pre>`
     : '';
   const disabled = approval.status !== 'pending' ? ' disabled' : '';
-  const selected = approval.id === window._selectedApprovalId ? ' selected' : '';
+  const selected =
+    approval.id === window._selectedApprovalId ? ' selected' : '';
   return `
     <article class="approval-card${selected}" data-id="${esc(approval.id)}">
       <div class="approval-card-main">
@@ -1030,7 +1036,11 @@ function renderApprovalPanel(approval) {
     ['Correlation', approval.correlationId || 'none'],
     ['Policy', approval.policyDecisionId || 'none'],
     ['Requester', approval.requester || 'system'],
-    ['Target', [approval.targetType, approval.targetId].filter(Boolean).join(' / ') || 'none'],
+    [
+      'Target',
+      [approval.targetType, approval.targetId].filter(Boolean).join(' / ') ||
+        'none',
+    ],
     ['Created', approval.createdAt || 'unknown'],
     ['Expires', approval.expiresAt || 'none'],
     ['Reviewed', approval.reviewedAt || 'not reviewed'],
@@ -1123,7 +1133,12 @@ async function renderApprovals(el) {
       </select>
       <select name="kind">
         <option value="">Any kind</option>
-        ${Object.entries(APPROVAL_KIND_LABELS).map(([kind, label]) => `<option value="${kind}" ${filters.kind === kind ? 'selected' : ''}>${esc(label)}</option>`).join('')}
+        ${Object.entries(APPROVAL_KIND_LABELS)
+          .map(
+            ([kind, label]) =>
+              `<option value="${kind}" ${filters.kind === kind ? 'selected' : ''}>${esc(label)}</option>`,
+          )
+          .join('')}
       </select>
       <input name="requester" value="${esc(filters.requester || '')}" placeholder="Requester">
       <input name="targetType" value="${esc(filters.targetType || '')}" placeholder="Target type">
@@ -1178,7 +1193,9 @@ window.selectApproval = function (id) {
   window._selectedApprovalId = id;
   document
     .querySelectorAll('.approval-card')
-    .forEach((card) => card.classList.toggle('selected', card.dataset.id === id));
+    .forEach((card) =>
+      card.classList.toggle('selected', card.dataset.id === id),
+    );
   if (currentPage === 'approvals') navigate('approvals');
 };
 
@@ -1188,14 +1205,20 @@ window.resetApprovalFilters = function () {
 };
 
 async function reviewInboxApproval(id, decision) {
-  const note = prompt(`${decision === 'approve' ? 'Approve' : 'Deny'} note`, '');
+  const note = prompt(
+    `${decision === 'approve' ? 'Approve' : 'Deny'} note`,
+    '',
+  );
   try {
     const data = await api(`/approvals/${encodeURIComponent(id)}/${decision}`, {
       method: 'POST',
       body: JSON.stringify({ note: note || undefined }),
     });
     if (data.error) throw new Error(data.error);
-    toast(`Approval ${decision === 'approve' ? 'approved' : 'denied'}`, 'success');
+    toast(
+      `Approval ${decision === 'approve' ? 'approved' : 'denied'}`,
+      'success',
+    );
     navigate('approvals');
   } catch (e) {
     toast('Approval review failed: ' + e.message, 'error');
@@ -2672,7 +2695,9 @@ async function renderMcp(el) {
             </div>
             <div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:10px">
               ${
-                !item.installed && item.setupPath === 'preset' && item.presetName
+                !item.installed &&
+                item.setupPath === 'preset' &&
+                item.presetName
                   ? `<button class="btn btn-sm btn-primary" onclick="installMcpPreset('${esc(item.presetName)}')">Install preset</button>`
                   : !item.installed && item.setupPath === 'manual'
                     ? `<button class="btn btn-sm btn-primary" onclick="document.getElementById('new-mcp-form').style.display='block';document.getElementById('new-mcp-form').scrollIntoView({behavior:'smooth',block:'start'})">Add server</button>`
@@ -3278,9 +3303,12 @@ async function renderReports(el) {
 }
 
 window.approveReportOutline = async (id) => {
-  const r = await api(`/reports/jobs/${encodeURIComponent(id)}/approve-outline`, {
-    method: 'POST',
-  });
+  const r = await api(
+    `/reports/jobs/${encodeURIComponent(id)}/approve-outline`,
+    {
+      method: 'POST',
+    },
+  );
   if (r.ok) {
     toast('Report outline approved', 'success');
     navigate('reports');
@@ -5241,7 +5269,8 @@ function renderAuditEventRow(event, selectedId) {
 }
 
 function renderAuditDetail(event, replay) {
-  if (!event) return '<aside class="audit-detail empty">Select an audit event</aside>';
+  if (!event)
+    return '<aside class="audit-detail empty">Select an audit event</aside>';
   const context = event.context || {
     ip: event.ip,
     details: event.details,
@@ -5263,7 +5292,10 @@ function renderAuditDetail(event, replay) {
         ['Duration', event.durationMs != null ? `${event.durationMs}ms` : '-'],
         ['Error', event.error || '-'],
       ]
-        .map(([label, value]) => `<div><span>${esc(label)}</span><strong>${esc(value)}</strong></div>`)
+        .map(
+          ([label, value]) =>
+            `<div><span>${esc(label)}</span><strong>${esc(value)}</strong></div>`,
+        )
         .join('')}
     </div>
     <div class="section-label">Context</div>
@@ -5274,7 +5306,8 @@ function renderAuditDetail(event, replay) {
           <div class="audit-replay">
             ${replay.events
               .map(
-                (item) => `<div><span>${formatTime(item.timestamp)}</span><strong>${esc(item.actionType)}</strong>${auditDecisionBadge(item.decision)}</div>`,
+                (item) =>
+                  `<div><span>${formatTime(item.timestamp)}</span><strong>${esc(item.actionType)}</strong>${auditDecisionBadge(item.decision)}</div>`,
               )
               .join('')}
           </div>`
@@ -5301,7 +5334,9 @@ async function renderAudit(el) {
   if (selected?.id) window._selectedAuditId = selected.id;
   const replay =
     selected?.correlationId && selected.correlationId !== '-'
-      ? await api(`/runtime-audit/replay/${encodeURIComponent(selected.correlationId)}`).catch(() => null)
+      ? await api(
+          `/runtime-audit/replay/${encodeURIComponent(selected.correlationId)}`,
+        ).catch(() => null)
       : null;
 
   el.innerHTML = `
@@ -5347,7 +5382,9 @@ async function renderAudit(el) {
 
   document.getElementById('audit-filters').onsubmit = (event) => {
     event.preventDefault();
-    window._auditFilters = Object.fromEntries(new FormData(event.currentTarget).entries());
+    window._auditFilters = Object.fromEntries(
+      new FormData(event.currentTarget).entries(),
+    );
     navigate('audit');
   };
   document.querySelector('.audit-list')?.addEventListener('click', (event) => {
@@ -5358,7 +5395,9 @@ async function renderAudit(el) {
   });
   document.getElementById('policy-simulator-form').onsubmit = async (event) => {
     event.preventDefault();
-    const data = Object.fromEntries(new FormData(event.currentTarget).entries());
+    const data = Object.fromEntries(
+      new FormData(event.currentTarget).entries(),
+    );
     let context = {};
     try {
       context = data.context ? JSON.parse(data.context) : {};
@@ -5376,7 +5415,8 @@ async function renderAudit(el) {
         context,
       }),
     });
-    document.getElementById('policy-simulator-output').textContent = prettyPrint(result);
+    document.getElementById('policy-simulator-output').textContent =
+      prettyPrint(result);
   };
 }
 
@@ -7102,15 +7142,93 @@ window.deleteWikiPage = async (name) => {
 // --- Workflows ---
 async function renderWorkflows(el) {
   let workflows = [];
+  let runbooks = [];
+  let missions = [];
   try {
     workflows = await api('/workflows');
   } catch {}
-  const groups = await api('/groups');
+  try {
+    runbooks = await api('/missions/runbooks');
+  } catch {}
+  try {
+    missions = await api('/missions');
+  } catch {}
+  let groups = [];
+  try {
+    groups = await api('/groups');
+  } catch {}
 
   el.innerHTML = `
     <div class="page-header">
       <h2>Workflows</h2>
-      <button class="btn btn-primary btn-sm" onclick="document.getElementById('new-workflow-form').style.display=document.getElementById('new-workflow-form').style.display==='none'?'block':'none'">New Workflow</button>
+      <div style="display:flex;gap:8px;align-items:center">
+        <button class="btn btn-sm btn-ghost" onclick="document.getElementById('new-runbook-form').style.display=document.getElementById('new-runbook-form').style.display==='none'?'block':'none'">New Runbook</button>
+        <button class="btn btn-primary btn-sm" onclick="document.getElementById('new-workflow-form').style.display=document.getElementById('new-workflow-form').style.display==='none'?'block':'none'">New Workflow</button>
+      </div>
+    </div>
+    <div class="grid grid-2" style="align-items:start;margin-bottom:16px">
+      <div class="card" id="new-runbook-form" style="display:none">
+        <div class="card-title">Create Runbook</div>
+        <form id="runbook-create-form">
+          <div class="form-group"><label>Title</label><input id="runbook-title" placeholder="Morning operations brief" required></div>
+          <div class="form-group"><label>Description</label><input id="runbook-description" placeholder="Reusable checklist for an operator mission"></div>
+          <div id="runbook-steps-list">
+            <div class="card-title" style="margin-top:8px">Steps</div>
+            <div class="runbook-step-row" style="display:grid;grid-template-columns:minmax(160px,1fr) minmax(220px,2fr) auto;gap:8px;margin-bottom:8px;align-items:end">
+              <div class="form-group" style="margin:0"><label>Step</label><input class="runbook-step-title" placeholder="Collect signals"></div>
+              <div class="form-group" style="margin:0"><label>Detail</label><input class="runbook-step-detail" placeholder="Review journal and inboxes"></div>
+              <label style="display:flex;gap:6px;align-items:center;font-size:12px;color:var(--text-muted);padding-bottom:10px"><input type="checkbox" class="runbook-step-approval"> Approval</label>
+            </div>
+          </div>
+          <div style="display:flex;gap:8px;margin-top:8px">
+            <button type="button" class="btn btn-sm btn-ghost" onclick="addRunbookStep()">+ Add Step</button>
+            <button type="submit" class="btn btn-primary btn-sm">Create Runbook</button>
+          </div>
+        </form>
+      </div>
+      <div class="card">
+        <div class="card-title">Start Mission</div>
+        <form id="mission-create-form">
+          <div class="form-group"><label>Mission Title</label><input id="mission-title" placeholder="Saturday briefing"></div>
+          <div class="grid grid-2">
+            <div class="form-group"><label>Runbook</label><select id="mission-runbook">${runbooks.map((runbook) => `<option value="${esc(runbook.id)}">${esc(runbook.title)}</option>`).join('')}</select></div>
+            <div class="form-group"><label>Owner</label><input id="mission-owner" placeholder="Operator"></div>
+          </div>
+          <button type="submit" class="btn btn-primary btn-sm" ${runbooks.length ? '' : 'disabled'}>Start Mission</button>
+        </form>
+      </div>
+    </div>
+    <div class="grid grid-2" style="align-items:start;margin-bottom:16px">
+      <div class="card">
+        <div class="card-title">Active Missions <span class="badge badge-muted">${missions.length}</span></div>
+        ${
+          missions.length === 0
+            ? '<div class="empty" style="padding:16px">No missions started</div>'
+            : missions.map(renderMissionCard).join('')
+        }
+      </div>
+      <div class="card">
+        <div class="card-title">Runbooks <span class="badge badge-muted">${runbooks.length}</span></div>
+        ${
+          runbooks.length === 0
+            ? '<div class="empty" style="padding:16px">No runbooks configured</div>'
+            : runbooks
+                .map(
+                  (runbook) => `
+          <div style="padding:10px 0;border-bottom:1px solid var(--border)">
+            <div style="display:flex;justify-content:space-between;gap:8px">
+              <strong style="color:var(--text)">${esc(runbook.title)}</strong>
+              <span class="badge badge-muted">${runbook.steps?.length || 0} steps</span>
+            </div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:4px">${esc(runbook.description || 'Reusable operator checklist')}</div>
+            <div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px">
+              ${(runbook.steps || []).map((step) => `<span class="badge ${step.requiresApproval ? 'badge-warning' : 'badge-info'}">${esc(step.title)}</span>`).join('')}
+            </div>
+          </div>`,
+                )
+                .join('')
+        }
+      </div>
     </div>
     <div class="card" id="new-workflow-form" style="display:none">
       <div class="card-title">Create Workflow</div>
@@ -7176,6 +7294,62 @@ async function renderWorkflows(el) {
   // Store groups for action rows
   window._wfGroups = groups;
 
+  const runbookForm = document.getElementById('runbook-create-form');
+  if (runbookForm)
+    runbookForm.onsubmit = async (e) => {
+      e.preventDefault();
+      const steps = Array.from(document.querySelectorAll('.runbook-step-row'))
+        .map((row) => ({
+          title: row.querySelector('.runbook-step-title')?.value?.trim() || '',
+          detail:
+            row.querySelector('.runbook-step-detail')?.value?.trim() ||
+            undefined,
+          requiresApproval:
+            row.querySelector('.runbook-step-approval')?.checked === true,
+        }))
+        .filter((step) => step.title);
+      if (steps.length === 0) {
+        toast('Add at least one runbook step', 'warning');
+        return;
+      }
+      const r = await api('/missions/runbooks', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: document.getElementById('runbook-title').value,
+          description: document.getElementById('runbook-description').value,
+          steps,
+        }),
+      }).catch(() => null);
+      if (r?.ok) {
+        toast('Runbook created', 'success');
+        navigate('workflows');
+      } else toast(r?.error || 'Failed to create runbook', 'error');
+    };
+
+  const missionForm = document.getElementById('mission-create-form');
+  if (missionForm)
+    missionForm.onsubmit = async (e) => {
+      e.preventDefault();
+      const runbookId = document.getElementById('mission-runbook')?.value;
+      const title = document.getElementById('mission-title')?.value?.trim();
+      if (!runbookId || !title) {
+        toast('Choose a runbook and title', 'warning');
+        return;
+      }
+      const r = await api('/missions', {
+        method: 'POST',
+        body: JSON.stringify({
+          title,
+          runbookId,
+          owner: document.getElementById('mission-owner')?.value,
+        }),
+      }).catch(() => null);
+      if (r?.ok) {
+        toast('Mission started', 'success');
+        navigate('workflows');
+      } else toast(r?.error || 'Failed to start mission', 'error');
+    };
+
   const form = document.getElementById('workflow-create-form');
   if (form)
     form.onsubmit = async (e) => {
@@ -7214,6 +7388,89 @@ async function renderWorkflows(el) {
       }
     };
 }
+
+function missionStatusBadge(status) {
+  if (status === 'completed') return 'badge-success';
+  if (status === 'blocked') return 'badge-error';
+  if (status === 'running') return 'badge-warning';
+  return 'badge-muted';
+}
+
+function renderMissionCard(mission) {
+  return `
+    <div style="padding:12px 0;border-bottom:1px solid var(--border)">
+      <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start">
+        <div>
+          <strong style="color:var(--text)">${esc(mission.title)}</strong>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:3px">${mission.owner ? 'Owner: ' + esc(mission.owner) + ' • ' : ''}Updated ${mission.updatedAt ? timeAgo(mission.updatedAt) : 'recently'}</div>
+        </div>
+        <span class="badge ${missionStatusBadge(mission.status)}">${esc(mission.status || 'pending')}</span>
+      </div>
+      <div style="margin-top:10px;display:flex;flex-direction:column;gap:8px">
+        ${(mission.steps || [])
+          .map(
+            (step, index) => `
+        <div style="display:grid;grid-template-columns:28px 1fr auto;gap:8px;align-items:center;padding:8px;background:var(--surface2);border-radius:var(--radius-sm)">
+          <span class="pipeline-step-num">${index + 1}</span>
+          <div>
+            <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+              <strong style="font-size:12px;color:var(--text)">${esc(step.title)}</strong>
+              <span class="badge ${missionStatusBadge(step.status)}">${esc(step.status)}</span>
+              ${step.requiresApproval ? '<span class="badge badge-warning">Approval</span>' : ''}
+            </div>
+            <div style="font-size:11px;color:var(--text-muted);margin-top:3px">${esc(step.note || step.detail || '')}</div>
+          </div>
+          <div style="display:flex;gap:4px;flex-wrap:wrap;justify-content:flex-end">
+            <button class="btn btn-sm btn-ghost" onclick="updateMissionStepStatus('${esc(mission.id)}','${esc(step.id)}','running')">Start</button>
+            <button class="btn btn-sm btn-success" onclick="updateMissionStepStatus('${esc(mission.id)}','${esc(step.id)}','completed',${step.requiresApproval ? 'true' : 'false'})">Done</button>
+            <button class="btn btn-sm btn-ghost" onclick="updateMissionStepStatus('${esc(mission.id)}','${esc(step.id)}','blocked')">Block</button>
+          </div>
+        </div>`,
+          )
+          .join('')}
+      </div>
+    </div>`;
+}
+
+window.addRunbookStep = () => {
+  const list = document.getElementById('runbook-steps-list');
+  if (!list) return;
+  const row = document.createElement('div');
+  row.className = 'runbook-step-row';
+  row.style.cssText =
+    'display:grid;grid-template-columns:minmax(160px,1fr) minmax(220px,2fr) auto auto;gap:8px;margin-bottom:8px;align-items:end';
+  row.innerHTML = `
+    <div class="form-group" style="margin:0"><input class="runbook-step-title" placeholder="Step title"></div>
+    <div class="form-group" style="margin:0"><input class="runbook-step-detail" placeholder="Step detail"></div>
+    <label style="display:flex;gap:6px;align-items:center;font-size:12px;color:var(--text-muted);padding-bottom:10px"><input type="checkbox" class="runbook-step-approval"> Approval</label>
+    <button type="button" class="btn btn-sm btn-danger" onclick="this.parentElement.remove()" style="margin-bottom:2px">X</button>`;
+  list.appendChild(row);
+};
+
+window.updateMissionStepStatus = async (
+  missionId,
+  stepId,
+  status,
+  requiresApproval,
+) => {
+  const payload = { status };
+  if (status === 'completed' && requiresApproval) {
+    const approvalId = prompt('Approval reference required');
+    if (!approvalId) {
+      toast('Approval reference required', 'warning');
+      return;
+    }
+    payload.approvalId = approvalId;
+  }
+  const r = await api(`/missions/${missionId}/steps/${stepId}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  }).catch(() => null);
+  if (r?.ok) {
+    toast('Mission step updated', 'success');
+    navigate('workflows');
+  } else toast(r?.error || 'Failed to update mission step', 'error');
+};
 
 window.addWorkflowAction = () => {
   const list = document.getElementById('wf-actions-list');

--- a/src/admin/routes/missions.test.ts
+++ b/src/admin/routes/missions.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+import type { Mission, Runbook } from '../../missions.js';
+
+const STORE_DIR = path.join(
+  os.tmpdir(),
+  `nanocrab-admin-missions-${Date.now()}`,
+);
+
+vi.mock('../../config.js', () => ({
+  STORE_DIR,
+}));
+
+vi.mock('../security.js', () => ({
+  auditLog: vi.fn(),
+}));
+
+const { default: missionsRouter } = await import('./missions.js');
+
+interface RunbookResponse {
+  runbook: Runbook;
+}
+
+interface MissionResponse {
+  mission: Mission;
+}
+
+function app(): express.Express {
+  const server = express();
+  server.use(express.json());
+  server.use('/missions', missionsRouter);
+  return server;
+}
+
+async function withServer<T>(
+  handler: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const server = http.createServer(app());
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Unable to allocate test server port');
+  }
+  try {
+    return await handler(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+}
+
+describe('mission admin routes', () => {
+  beforeEach(() => {
+    fs.rmSync(STORE_DIR, { recursive: true, force: true });
+  });
+
+  it('creates runbooks, starts missions, and updates steps through the API', async () => {
+    await withServer(async (baseUrl) => {
+      const runbookRes = await fetch(new URL('/missions/runbooks', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Launch Briefing',
+          steps: [{ title: 'Collect notes' }, { title: 'Draft message' }],
+        }),
+      });
+      expect(runbookRes.status).toBe(200);
+      const runbookBody = (await runbookRes.json()) as RunbookResponse;
+
+      const missionRes = await fetch(new URL('/missions', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Saturday launch',
+          runbookId: runbookBody.runbook.id,
+        }),
+      });
+      expect(missionRes.status).toBe(200);
+      const missionBody = (await missionRes.json()) as MissionResponse;
+
+      const stepRes = await fetch(
+        new URL(
+          `/missions/${missionBody.mission.id}/steps/${missionBody.mission.steps[0].id}`,
+          baseUrl,
+        ),
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'completed', note: 'Done' }),
+        },
+      );
+      expect(stepRes.status).toBe(200);
+      const stepBody = (await stepRes.json()) as MissionResponse;
+      expect(stepBody.mission.steps[0]).toMatchObject({
+        status: 'completed',
+        note: 'Done',
+      });
+    });
+  });
+
+  it('returns a 400 when completing approval-required steps without approval', async () => {
+    await withServer(async (baseUrl) => {
+      const runbookRes = await fetch(new URL('/missions/runbooks', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'External Publish',
+          steps: [{ title: 'Send message', requiresApproval: true }],
+        }),
+      });
+      const runbookBody = (await runbookRes.json()) as RunbookResponse;
+      const missionRes = await fetch(new URL('/missions', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Publish orders',
+          runbookId: runbookBody.runbook.id,
+        }),
+      });
+      const missionBody = (await missionRes.json()) as MissionResponse;
+
+      const res = await fetch(
+        new URL(
+          `/missions/${missionBody.mission.id}/steps/${missionBody.mission.steps[0].id}`,
+          baseUrl,
+        ),
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'completed' }),
+        },
+      );
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({
+        error: expect.stringMatching(/approval reference/i),
+      });
+    });
+  });
+});

--- a/src/admin/routes/missions.ts
+++ b/src/admin/routes/missions.ts
@@ -1,0 +1,68 @@
+import { Router, type Request, type Response } from 'express';
+import {
+  createMissionFromRunbook,
+  createRunbook,
+  loadMissionStore,
+  updateMissionStep,
+} from '../../missions.js';
+import { auditLog } from '../security.js';
+
+const router = Router();
+
+function sendError(res: Response, err: unknown) {
+  const message = err instanceof Error ? err.message : 'Mission request failed';
+  const status = /not found/i.test(message)
+    ? 404
+    : /required|approval|at least/i.test(message)
+      ? 400
+      : 500;
+  res.status(status).json({ error: message });
+}
+
+router.get('/', (_req: Request, res: Response) => {
+  res.json(loadMissionStore().missions);
+});
+
+router.get('/runbooks', (_req: Request, res: Response) => {
+  res.json(loadMissionStore().runbooks);
+});
+
+router.post('/runbooks', (req: Request, res: Response) => {
+  try {
+    const runbook = createRunbook(req.body || {});
+    auditLog(req, 'runbook_create', `${runbook.title} (${runbook.id})`);
+    res.json({ ok: true, runbook });
+  } catch (err) {
+    sendError(res, err);
+  }
+});
+
+router.post('/', (req: Request, res: Response) => {
+  try {
+    const mission = createMissionFromRunbook(req.body || {});
+    auditLog(req, 'mission_create', `${mission.title} (${mission.id})`);
+    res.json({ ok: true, mission });
+  } catch (err) {
+    sendError(res, err);
+  }
+});
+
+router.put('/:missionId/steps/:stepId', (req: Request, res: Response) => {
+  try {
+    const mission = updateMissionStep(
+      req.params.missionId as string,
+      req.params.stepId as string,
+      req.body || {},
+    );
+    auditLog(
+      req,
+      'mission_step_update',
+      `${mission.id}:${req.params.stepId}:${req.body?.status || 'unknown'}`,
+    );
+    res.json({ ok: true, mission });
+  } catch (err) {
+    sendError(res, err);
+  }
+});
+
+export default router;

--- a/src/missions.test.ts
+++ b/src/missions.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  createMissionFromRunbook,
+  createRunbook,
+  loadMissionStore,
+  updateMissionStep,
+} from './missions.js';
+
+function tempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-missions-'));
+  return path.join(dir, 'missions.json');
+}
+
+describe('missions and runbooks', () => {
+  it('creates a mission from a runbook and tracks step progress', () => {
+    const storePath = tempStore();
+    const runbook = createRunbook(
+      {
+        title: 'Morning Operations',
+        description: 'Review overnight state and prepare the day.',
+        steps: [
+          { title: 'Collect signals', detail: 'Read overnight summaries.' },
+          { title: 'Draft plan', detail: 'Prepare the operator brief.' },
+        ],
+      },
+      { storePath, now: () => '2026-06-13T08:00:00.000Z' },
+    );
+
+    const mission = createMissionFromRunbook(
+      {
+        runbookId: runbook.id,
+        title: 'Saturday briefing',
+        owner: 'Henrik',
+      },
+      { storePath, now: () => '2026-06-13T08:05:00.000Z' },
+    );
+
+    const updated = updateMissionStep(
+      mission.id,
+      mission.steps[0].id,
+      { status: 'completed', note: 'Signals collected from journal.' },
+      { storePath, now: () => '2026-06-13T08:10:00.000Z' },
+    );
+
+    expect(updated.status).toBe('running');
+    expect(updated.steps[0]).toMatchObject({
+      title: 'Collect signals',
+      status: 'completed',
+      note: 'Signals collected from journal.',
+      completedAt: '2026-06-13T08:10:00.000Z',
+    });
+    expect(updated.steps[1].status).toBe('pending');
+
+    const persisted = loadMissionStore(storePath);
+    expect(persisted.runbooks).toHaveLength(1);
+    expect(persisted.missions[0].steps[0].status).toBe('completed');
+  });
+
+  it('does not complete approval-required mission steps without an approval reference', () => {
+    const storePath = tempStore();
+    const runbook = createRunbook(
+      {
+        title: 'Publish Orders',
+        steps: [
+          {
+            title: 'Send orders',
+            detail: 'Publish to the operations channel.',
+            requiresApproval: true,
+          },
+        ],
+      },
+      { storePath },
+    );
+    const mission = createMissionFromRunbook(
+      { runbookId: runbook.id, title: 'Nightfall orders' },
+      { storePath },
+    );
+
+    expect(() =>
+      updateMissionStep(
+        mission.id,
+        mission.steps[0].id,
+        { status: 'completed' },
+        { storePath },
+      ),
+    ).toThrow(/approval reference/i);
+  });
+});

--- a/src/missions.ts
+++ b/src/missions.ts
@@ -1,0 +1,245 @@
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { STORE_DIR } from './config.js';
+
+export type MissionStatus = 'pending' | 'running' | 'completed' | 'blocked';
+export type MissionStepStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'blocked'
+  | 'skipped';
+
+export interface RunbookStep {
+  id: string;
+  title: string;
+  detail?: string;
+  requiresApproval: boolean;
+}
+
+export interface Runbook {
+  id: string;
+  title: string;
+  description?: string;
+  steps: RunbookStep[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MissionStep extends RunbookStep {
+  status: MissionStepStatus;
+  note?: string;
+  approvalId?: string;
+  startedAt?: string;
+  completedAt?: string;
+  updatedAt: string;
+}
+
+export interface Mission {
+  id: string;
+  title: string;
+  owner?: string;
+  runbookId?: string;
+  status: MissionStatus;
+  steps: MissionStep[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MissionStore {
+  runbooks: Runbook[];
+  missions: Mission[];
+}
+
+export interface MissionStoreOptions {
+  storePath?: string;
+  now?: () => string;
+}
+
+export interface CreateRunbookInput {
+  title: string;
+  description?: string;
+  steps: Array<{
+    title: string;
+    detail?: string;
+    requiresApproval?: boolean;
+  }>;
+}
+
+export interface CreateMissionInput {
+  title: string;
+  owner?: string;
+  runbookId?: string;
+  steps?: Array<{
+    title: string;
+    detail?: string;
+    requiresApproval?: boolean;
+  }>;
+}
+
+export interface UpdateMissionStepInput {
+  status: MissionStepStatus;
+  note?: string;
+  approvalId?: string;
+}
+
+export const DEFAULT_MISSION_STORE = path.join(STORE_DIR, 'missions.json');
+
+function now(options?: MissionStoreOptions) {
+  return options?.now?.() || new Date().toISOString();
+}
+
+function storePath(options?: MissionStoreOptions) {
+  return options?.storePath || DEFAULT_MISSION_STORE;
+}
+
+function emptyStore(): MissionStore {
+  return { runbooks: [], missions: [] };
+}
+
+export function loadMissionStore(
+  filePath = DEFAULT_MISSION_STORE,
+): MissionStore {
+  try {
+    if (!fs.existsSync(filePath)) return emptyStore();
+    const raw = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8'),
+    ) as Partial<MissionStore>;
+    return {
+      runbooks: Array.isArray(raw.runbooks) ? raw.runbooks : [],
+      missions: Array.isArray(raw.missions) ? raw.missions : [],
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+export function saveMissionStore(
+  store: MissionStore,
+  filePath = DEFAULT_MISSION_STORE,
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+function assertTitle(title: string, field = 'title') {
+  if (!title || !title.trim()) throw new Error(`${field} is required`);
+}
+
+function normalizeRunbookSteps(
+  input: CreateRunbookInput['steps'],
+): RunbookStep[] {
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error('At least one runbook step is required');
+  }
+  return input.map((step, index) => {
+    assertTitle(step.title, `steps[${index}].title`);
+    return {
+      id: randomUUID(),
+      title: step.title.trim(),
+      detail: step.detail?.trim() || undefined,
+      requiresApproval: step.requiresApproval === true,
+    };
+  });
+}
+
+function missionStepsFromRunbook(steps: RunbookStep[], timestamp: string) {
+  return steps.map((step) => ({
+    ...step,
+    status: 'pending' as MissionStepStatus,
+    updatedAt: timestamp,
+  }));
+}
+
+export function createRunbook(
+  input: CreateRunbookInput,
+  options?: MissionStoreOptions,
+): Runbook {
+  assertTitle(input.title);
+  const timestamp = now(options);
+  const store = loadMissionStore(storePath(options));
+  const runbook: Runbook = {
+    id: randomUUID(),
+    title: input.title.trim(),
+    description: input.description?.trim() || undefined,
+    steps: normalizeRunbookSteps(input.steps),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  store.runbooks.push(runbook);
+  saveMissionStore(store, storePath(options));
+  return runbook;
+}
+
+export function createMissionFromRunbook(
+  input: CreateMissionInput,
+  options?: MissionStoreOptions,
+): Mission {
+  assertTitle(input.title);
+  const timestamp = now(options);
+  const store = loadMissionStore(storePath(options));
+  const runbook = input.runbookId
+    ? store.runbooks.find((candidate) => candidate.id === input.runbookId)
+    : undefined;
+  const sourceSteps = runbook
+    ? runbook.steps
+    : normalizeRunbookSteps(input.steps || []);
+  const mission: Mission = {
+    id: randomUUID(),
+    title: input.title.trim(),
+    owner: input.owner?.trim() || undefined,
+    runbookId: runbook?.id,
+    status: 'pending',
+    steps: missionStepsFromRunbook(sourceSteps, timestamp),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  store.missions.push(mission);
+  saveMissionStore(store, storePath(options));
+  return mission;
+}
+
+function summarizeMissionStatus(steps: MissionStep[]): MissionStatus {
+  if (steps.some((step) => step.status === 'blocked')) return 'blocked';
+  if (steps.every((step) => ['completed', 'skipped'].includes(step.status))) {
+    return 'completed';
+  }
+  if (steps.some((step) => step.status !== 'pending')) return 'running';
+  return 'pending';
+}
+
+export function updateMissionStep(
+  missionId: string,
+  stepId: string,
+  input: UpdateMissionStepInput,
+  options?: MissionStoreOptions,
+): Mission {
+  const store = loadMissionStore(storePath(options));
+  const mission = store.missions.find(
+    (candidate) => candidate.id === missionId,
+  );
+  if (!mission) throw new Error('Mission not found');
+  const step = mission.steps.find((candidate) => candidate.id === stepId);
+  if (!step) throw new Error('Mission step not found');
+  if (
+    step.requiresApproval &&
+    input.status === 'completed' &&
+    !input.approvalId &&
+    !step.approvalId
+  ) {
+    throw new Error('Approval reference is required to complete this step');
+  }
+
+  const timestamp = now(options);
+  step.status = input.status;
+  step.note = input.note?.trim() || step.note;
+  step.approvalId = input.approvalId?.trim() || step.approvalId;
+  step.updatedAt = timestamp;
+  if (input.status === 'running' && !step.startedAt) step.startedAt = timestamp;
+  if (input.status === 'completed') step.completedAt = timestamp;
+  mission.status = summarizeMissionStatus(mission.steps);
+  mission.updatedAt = timestamp;
+  saveMissionStore(store, storePath(options));
+  return mission;
+}


### PR DESCRIPTION
## Summary
- add a JSON-backed missions/runbooks service with step status tracking
- expose admin APIs for runbooks, mission creation, and mission step updates
- add Workflows dashboard panels plus mock-mode mission/runbook data
- update README and roadmap notes for the new personal operations layer

## Safety
- approval-required mission steps cannot be completed without an approval reference
- dashboard completion flow prompts for an approval reference before sending the update

## Validation
- `rtk mise exec node@22 -- npx vitest run src/missions.test.ts src/admin/routes/missions.test.ts`
- `rtk mise exec node@22 -- npm run typecheck`
- `rtk mise exec node@22 -- npm run build`
- `rtk mise exec node@22 -- npm test`
- `rtk mise exec node@22 -- npm run format:check`
- `rtk node --check src/admin/public/app.js`
- mock admin browser smoke test for `#/workflows`

Fixes #33
