### PR TITLE
Add repo coding rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Additional plugins can be installed from git URLs via the Marketplace page, or c
 
 - **Coding Task Launcher** — pick tool (Claude Code / Codex / Copilot), model, working directory, and describe the task
 - **GitHub Coding Jobs** — register enabled repos, pick issues by repo/label/assignee/milestone/number, inspect diffs/output/tests/CI, approve implementation, approve PRs, retry, cancel, and revert
+- **Repo Coding Rules** — save reviewed repo preferences such as required runtimes, test commands, and safety conventions; approved rules are injected into coding-job prompts without exposing secrets.
 - **Isolated Coding Jobs** — WhatsApp/Signal/Telegram agents can request repo coding jobs through MCP; an ephemeral coding container clones and edits inside `data/coding-workspaces`
 - **Scheduled Tasks** — recurring coding jobs (hourly, daily, weekly)
 - **GitHub Autofix Pipeline** — webhook-driven: issue created/labeled → approval-gated coding job → reviewed PR publish → bot notifies you

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -172,6 +172,7 @@ Goal: work with GitHub repos and produce PRs while the owner is on the go.
 
 - GitHub connector:
   - DONE: repo registration/allowlist for coding jobs
+  - DONE: repo-specific coding rules/preferences are stored separately from secrets and injected into coding prompts.
   - DONE: issue listing and issue picking through dashboard/API
   - DONE: branch creation inside dedicated coding containers
   - commit signing policy

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -3792,6 +3792,33 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
       },
     ];
   }
+  if (pathname === '/agents/coding/repo-rules') {
+    return [
+      {
+        id: 'repo-rule-node22',
+        repo: 'henrikogaard/nanocrab',
+        title: 'Use Node 22',
+        content: 'Run checks through `rtk mise exec node@22 -- ...`.',
+        source: 'memory:mock-node22',
+        status: 'approved',
+        visibility: 'shared',
+        createdAt: iso(240),
+        updatedAt: iso(30),
+      },
+      {
+        id: 'repo-rule-approval-gates',
+        repo: 'henrikogaard/nanocrab',
+        title: 'Preserve approval gates',
+        content:
+          'Repo mutations, external sends, uploads, and PR creation stay approval-gated.',
+        source: 'memory:mock-approval-gates',
+        status: 'approved',
+        visibility: 'shared',
+        createdAt: iso(220),
+        updatedAt: iso(25),
+      },
+    ];
+  }
   if (pathname === '/agents/coding/jobs') {
     return [
       {

--- a/src/admin/public/pages/agents.js
+++ b/src/admin/public/pages/agents.js
@@ -47,6 +47,7 @@ async function renderAgents(el) {
       tools,
       agentTasks,
       codingRepos,
+      codingRepoRules,
       codingJobs,
       agentProviders,
       pendingQuestions,
@@ -65,6 +66,7 @@ async function renderAgents(el) {
       api('/agents/tools').catch(() => []),
       api('/agents/tasks').catch(() => []),
       api('/agents/coding/repos').catch(() => []),
+      api('/agents/coding/repo-rules').catch(() => []),
       api('/agents/coding/jobs').catch(() => []),
       api('/agents/providers').catch(() => []),
       api('/questions/pending').catch(() => []),
@@ -225,6 +227,22 @@ async function renderAgents(el) {
         (r) => `<option value="${esc(r.fullName)}">${esc(r.fullName)}</option>`,
       )
       .join('');
+    const codingRepoRuleRows =
+      codingRepoRules.length === 0
+        ? '<div class="empty" style="padding:10px">No repo coding rules saved yet</div>'
+        : codingRepoRules
+            .map(
+              (rule) => `
+        <div style="padding:8px 0;border-bottom:1px solid var(--border)">
+          <div style="display:flex;justify-content:space-between;gap:8px;align-items:flex-start">
+            <strong style="font-size:12px;color:var(--text)">${esc(rule.title)}</strong>
+            <span class="badge ${rule.status === 'approved' ? 'badge-success' : 'badge-muted'}">${esc(rule.status)}</span>
+          </div>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:3px">${esc(rule.repo)} • ${esc(rule.visibility || 'shared')}</div>
+          <div style="font-size:12px;color:var(--text-muted);margin-top:5px;line-height:1.35">${esc(rule.content)}</div>
+        </div>`,
+            )
+            .join('');
     const codingJobRows = codingJobs
       .map((job) => {
         const statusBadge = codingJobStatusBadge(job.status);
@@ -375,6 +393,17 @@ async function renderAgents(el) {
             ? '<div class="empty" style="padding:12px">No dedicated coding jobs yet</div>'
             : codingJobRows
         }
+      </div>
+
+      <div class="card" style="margin-bottom:16px">
+        <div class="card-title">Repo Coding Rules <span class="badge badge-muted" style="font-size:10px">${codingRepoRules.length}</span></div>
+        <div style="display:grid;grid-template-columns:minmax(160px,220px) 1fr 2fr auto;gap:6px;margin-bottom:12px;align-items:end">
+          <div><label style="font-size:11px;color:var(--text-muted)">Repo</label><select class="search-input" id="repo-rule-repo">${codingRepoOptions || '<option value="">No repos</option>'}</select></div>
+          <div><label style="font-size:11px;color:var(--text-muted)">Title</label><input class="search-input" id="repo-rule-title" placeholder="Use Node 22"></div>
+          <div><label style="font-size:11px;color:var(--text-muted)">Rule</label><input class="search-input" id="repo-rule-content" placeholder="Run checks through npm scripts"></div>
+          <button class="btn btn-sm btn-primary" onclick="saveRepoCodingRule()">Save Rule</button>
+        </div>
+        ${codingRepoRuleRows}
       </div>
 
       <div class="card" style="margin-bottom:16px">
@@ -639,6 +668,40 @@ window.registerCodingRepo = async function () {
       navigate('agents');
     } else {
       toast(r.error || 'Failed', 'error');
+    }
+  } catch (e) {
+    toast('Failed: ' + e.message, 'error');
+  }
+};
+
+window.saveRepoCodingRule = async function () {
+  const repo = document.getElementById('repo-rule-repo')?.value?.trim();
+  const title = document.getElementById('repo-rule-title')?.value?.trim();
+  const content = document.getElementById('repo-rule-content')?.value?.trim();
+  if (!repo || !title || !content) {
+    toast('Choose a repo and enter a rule title and body', 'warning');
+    return;
+  }
+  try {
+    const [owner, name] = repo.split('/');
+    const r = await api(
+      `/agents/coding/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/rules`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          title,
+          content,
+          source: 'dashboard',
+          visibility: 'shared',
+          status: 'approved',
+        }),
+      },
+    );
+    if (r.ok) {
+      toast('Repo rule saved', 'success');
+      navigate('agents');
+    } else {
+      toast(r.error || 'Failed to save rule', 'error');
     }
   } catch (e) {
     toast('Failed: ' + e.message, 'error');

--- a/src/admin/routes/agents.ts
+++ b/src/admin/routes/agents.ts
@@ -40,6 +40,11 @@ import {
   revertCodingJob,
   startCodingJob,
 } from '../../coding-jobs.js';
+import {
+  listAllRepoRules,
+  listRepoRules,
+  upsertRepoRule,
+} from '../../repo-preferences.js';
 
 const router = Router();
 const TASKS_PATH = path.join(STORE_DIR, 'agent-tasks.json');
@@ -150,6 +155,48 @@ router.post('/coding/repos', async (req: Request, res: Response) => {
     });
   }
 });
+
+router.get('/coding/repo-rules', (_req: Request, res: Response) => {
+  res.json(listAllRepoRules());
+});
+
+router.get(
+  '/coding/repos/:owner/:name/rules',
+  (req: Request, res: Response) => {
+    try {
+      const repo = `${req.params.owner}/${req.params.name}`;
+      res.json(listRepoRules(repo));
+    } catch (err) {
+      res.status(400).json({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+);
+
+router.post(
+  '/coding/repos/:owner/:name/rules',
+  (req: Request, res: Response) => {
+    try {
+      const repo = `${req.params.owner}/${req.params.name}`;
+      const rule = upsertRepoRule({
+        id: typeof req.body.id === 'string' ? req.body.id : undefined,
+        repo,
+        title: req.body.title,
+        content: req.body.content,
+        source: req.body.source || 'dashboard',
+        visibility: req.body.visibility === 'private' ? 'private' : 'shared',
+        status: req.body.status === 'disabled' ? 'disabled' : 'approved',
+      });
+      auditLog(req, 'coding_repo_rule_upserted', `${repo}:${rule.id}`);
+      res.json({ ok: true, rule });
+    } catch (err) {
+      res.status(400).json({
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+);
 
 router.get('/coding/jobs', (_req: Request, res: Response) => {
   res.json(

--- a/src/coding-jobs.test.ts
+++ b/src/coding-jobs.test.ts
@@ -59,6 +59,7 @@ vi.mock('child_process', () => ({
 
 import {
   approveCodingJob,
+  buildCodingPrompt,
   listGitHubIssues,
   loadCodingJobs,
   loadCodingRepos,
@@ -70,6 +71,7 @@ import {
   startCodingJob,
   transitionCodingJob,
 } from './coding-jobs.js';
+import { upsertRepoRule } from './repo-preferences.js';
 import { resolveProviderFallbackForAction } from './provider-router.js';
 import { createApproval, reviewApproval } from './approvals.js';
 import { listAuditEvents } from './audit-log.js';
@@ -340,6 +342,27 @@ describe('coding jobs', () => {
     expect(job.workspace).toContain('/data/coding-workspaces/jobs/');
     expect(loadCodingJobs()).toHaveLength(1);
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('includes approved repo preference rules in coding prompts', async () => {
+    mockGitHubFetch(() => ({ default_branch: 'main' }));
+    await registerCodingRepo({ repo: 'owner/repo' });
+    upsertRepoRule({
+      repo: 'owner/repo',
+      title: 'Use npm scripts',
+      content: 'Run the repo npm scripts instead of ad-hoc shell checks.',
+      source: 'memory:repo-rule',
+    });
+
+    const job = await startCodingJob({
+      repo: 'owner/repo',
+      prompt: 'Update dashboard code.',
+      requestedBy: 'dashboard',
+    });
+
+    expect(buildCodingPrompt(job)).toContain(
+      '- Use npm scripts: Run the repo npm scripts instead of ad-hoc shell checks.',
+    );
   });
 
   it('dry-runs coding jobs without spawning a write-capable container', async () => {

--- a/src/coding-jobs.ts
+++ b/src/coding-jobs.ts
@@ -34,6 +34,7 @@ import {
 import { resolveProviderFallbackForAction } from './provider-router.js';
 import { logAuditEvent } from './audit-log.js';
 import { evaluatePolicy } from './policy-engine.js';
+import { buildRepoRulesContext } from './repo-preferences.js';
 
 const CODING_REPOS_PATH = path.join(STORE_DIR, 'coding-repos.json');
 const CODING_JOBS_PATH = path.join(STORE_DIR, 'coding-jobs.json');
@@ -568,13 +569,15 @@ function updateJobOutput(job: CodingJob, text: string): void {
   upsertCodingJob(job);
 }
 
-function buildCodingPrompt(job: CodingJob): string {
+export function buildCodingPrompt(job: CodingJob): string {
+  const repoRules = buildRepoRulesContext(job.repo);
   const prompt = [
     `You are working in the cloned repository ${job.repo}.`,
     job.issueNumber
       ? `Fix GitHub issue #${job.issueNumber}: ${job.issueTitle || ''}`
       : 'Complete the requested coding task.',
     job.prompt,
+    repoRules || '',
     'Instructions:',
     '1. Inspect the repository before editing.',
     '2. Make focused changes only.',

--- a/src/repo-preferences.test.ts
+++ b/src/repo-preferences.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRepoRulesContext,
+  listRepoRules,
+  upsertRepoRule,
+} from './repo-preferences.js';
+
+function tempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanocrab-repo-rules-'));
+  return path.join(dir, 'repo-rules.json');
+}
+
+describe('repo preference rules', () => {
+  it('stores approved repo rules and builds coding prompt context', () => {
+    const storePath = tempStore();
+
+    const rule = upsertRepoRule(
+      {
+        repo: 'henrikogaard/nanocrab',
+        title: 'Use Node 22',
+        content: 'Run checks through `rtk mise exec node@22 -- ...`.',
+        source: 'memory:mem-1',
+        visibility: 'shared',
+      },
+      { storePath, now: () => '2026-06-13T09:00:00.000Z', id: () => 'rule-1' },
+    );
+
+    expect(rule).toMatchObject({
+      id: 'rule-1',
+      repo: 'henrikogaard/nanocrab',
+      status: 'approved',
+      visibility: 'shared',
+    });
+    expect(listRepoRules('henrikogaard/nanocrab', { storePath })).toHaveLength(
+      1,
+    );
+    expect(
+      buildRepoRulesContext('henrikogaard/nanocrab', { storePath }),
+    ).toContain('- Use Node 22: Run checks through');
+  });
+
+  it('rejects secret-looking repo rules so credentials do not enter coding prompts', () => {
+    expect(() =>
+      upsertRepoRule(
+        {
+          repo: 'henrikogaard/nanocrab',
+          title: 'Token',
+          content: 'Use API token sk-secret before running tests.',
+          visibility: 'shared',
+        },
+        { storePath: tempStore() },
+      ),
+    ).toThrow(/secret/i);
+  });
+});

--- a/src/repo-preferences.ts
+++ b/src/repo-preferences.ts
@@ -1,0 +1,163 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+import { STORE_DIR } from './config.js';
+
+export type RepoRuleStatus = 'approved' | 'disabled';
+export type RepoRuleVisibility = 'private' | 'shared';
+
+export interface RepoPreferenceRule {
+  id: string;
+  repo: string;
+  title: string;
+  content: string;
+  source: string | null;
+  status: RepoRuleStatus;
+  visibility: RepoRuleVisibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RepoPreferenceStore {
+  rules: RepoPreferenceRule[];
+}
+
+export interface UpsertRepoRuleInput {
+  id?: string;
+  repo: string;
+  title: string;
+  content: string;
+  source?: string | null;
+  visibility?: RepoRuleVisibility;
+  status?: RepoRuleStatus;
+}
+
+export interface RepoPreferenceOptions {
+  storePath?: string;
+  now?: () => string;
+  id?: () => string;
+}
+
+export const DEFAULT_REPO_PREFERENCES_PATH = path.join(
+  STORE_DIR,
+  'repo-preferences.json',
+);
+
+function storePath(options?: RepoPreferenceOptions) {
+  return options?.storePath || DEFAULT_REPO_PREFERENCES_PATH;
+}
+
+function now(options?: RepoPreferenceOptions) {
+  return options?.now?.() || new Date().toISOString();
+}
+
+function nextId(options?: RepoPreferenceOptions) {
+  return (
+    options?.id?.() ||
+    `repo-rule-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
+  );
+}
+
+function assertRepo(repo: string) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error('repo must be in owner/name format');
+  }
+}
+
+function containsSecret(text: string) {
+  return /\b(api[_ -]?key|token|password|secret|private key|oauth|sk-[A-Za-z0-9_-]{6,})\b/i.test(
+    text,
+  );
+}
+
+export function loadRepoPreferenceStore(
+  filePath = DEFAULT_REPO_PREFERENCES_PATH,
+): RepoPreferenceStore {
+  try {
+    if (!fs.existsSync(filePath)) return { rules: [] };
+    const raw = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8'),
+    ) as Partial<RepoPreferenceStore>;
+    return { rules: Array.isArray(raw.rules) ? raw.rules : [] };
+  } catch {
+    return { rules: [] };
+  }
+}
+
+export function saveRepoPreferenceStore(
+  store: RepoPreferenceStore,
+  filePath = DEFAULT_REPO_PREFERENCES_PATH,
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`);
+}
+
+export function listRepoRules(
+  repo: string,
+  options?: RepoPreferenceOptions,
+): RepoPreferenceRule[] {
+  assertRepo(repo);
+  return loadRepoPreferenceStore(storePath(options))
+    .rules.filter((rule) => rule.repo.toLowerCase() === repo.toLowerCase())
+    .sort((a, b) => a.title.localeCompare(b.title));
+}
+
+export function listAllRepoRules(
+  options?: RepoPreferenceOptions,
+): RepoPreferenceRule[] {
+  return loadRepoPreferenceStore(storePath(options)).rules.sort((a, b) =>
+    a.repo === b.repo
+      ? a.title.localeCompare(b.title)
+      : a.repo.localeCompare(b.repo),
+  );
+}
+
+export function upsertRepoRule(
+  input: UpsertRepoRuleInput,
+  options?: RepoPreferenceOptions,
+): RepoPreferenceRule {
+  assertRepo(input.repo);
+  const title = input.title.trim();
+  const content = input.content.trim();
+  if (!title) throw new Error('rule title is required');
+  if (!content) throw new Error('rule content is required');
+  if (containsSecret(`${title}\n${content}`)) {
+    throw new Error('Repo rules must not contain secrets or credentials');
+  }
+  const timestamp = now(options);
+  const store = loadRepoPreferenceStore(storePath(options));
+  const existingIndex = input.id
+    ? store.rules.findIndex((rule) => rule.id === input.id)
+    : -1;
+  const existing = existingIndex >= 0 ? store.rules[existingIndex] : undefined;
+  const rule: RepoPreferenceRule = {
+    id: existing?.id || input.id || nextId(options),
+    repo: input.repo,
+    title,
+    content,
+    source: input.source?.trim() || existing?.source || null,
+    status: input.status || existing?.status || 'approved',
+    visibility: input.visibility || existing?.visibility || 'shared',
+    createdAt: existing?.createdAt || timestamp,
+    updatedAt: timestamp,
+  };
+  if (existingIndex >= 0) store.rules[existingIndex] = rule;
+  else store.rules.push(rule);
+  saveRepoPreferenceStore(store, storePath(options));
+  return rule;
+}
+
+export function buildRepoRulesContext(
+  repo: string,
+  options?: RepoPreferenceOptions,
+): string {
+  const rules = listRepoRules(repo, options).filter(
+    (rule) => rule.status === 'approved',
+  );
+  if (rules.length === 0) return '';
+  return [
+    'Repository coding rules and preferences:',
+    ...rules.map((rule) => `- ${rule.title}: ${rule.content}`),
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
- add a repo preference/rules store with secret scanning
- inject approved repo rules into coding-job prompts
- expose repo-rule APIs under the coding agents routes
- add Agents dashboard UI and mock-mode repo rule samples
- update README and roadmap notes

## Safety
- repo rules reject secret-looking content before it can be saved or injected into coding prompts
- repo mutations and PR creation remain on the existing approval-gated coding job path

## Validation
- `rtk mise exec node@22 -- npx vitest run src/repo-preferences.test.ts src/coding-jobs.test.ts -t "repo preference|includes approved repo preference rules"`
- `rtk mise exec node@22 -- npm run typecheck`
- `rtk mise exec node@22 -- npm run build`
- `rtk mise exec node@22 -- npm test`
- `rtk mise exec node@22 -- npm run format:check`
- `rtk node --check src/admin/public/pages/agents.js`
- mock admin browser smoke test for `#/agents`

Fixes #31
