### PR TITLE
Add mobile coding job commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional plugins can be installed from git URLs via the Marketplace page, or c
 - **GitHub Coding Jobs** — register enabled repos, pick issues by repo/label/assignee/milestone/number, inspect diffs/output/tests/CI, approve implementation, approve PRs, retry, cancel, and revert
 - **Repo Coding Rules** — save reviewed repo preferences such as required runtimes, test commands, and safety conventions; approved rules are injected into coding-job prompts without exposing secrets.
 - **Isolated Coding Jobs** — WhatsApp/Signal/Telegram agents can request repo coding jobs through MCP; an ephemeral coding container clones and edits inside `data/coding-workspaces`
+- **Mobile Coding Commands** — the main control group can use `/code repos`, `/code start`, `/code pick`, `/code status`, and `/code approve|cancel|retry|open-pr` to drive coding jobs from chat.
 - **Scheduled Tasks** — recurring coding jobs (hourly, daily, weekly)
 - **GitHub Autofix Pipeline** — webhook-driven: issue created/labeled → approval-gated coding job → reviewed PR publish → bot notifies you
 - **GitHub Connector Health** — Webhooks shows the receiver URL, secret/target/event setup, recent deliveries, and read-only connector health checks without revealing credentials

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -10,13 +10,19 @@ NanoCrab has three command surfaces:
 
 These are exact text commands intercepted by the NanoCrab host before they are stored as normal messages.
 
-| Command | Where | Who | What It Does |
-| --- | --- | --- | --- |
-| `/update-nanocrab` | Main control group | Main group only | Starts the host-side updater from the latest NanoCrab GitHub release. Writes logs under `store/updates/` and may restart the service. |
-| `/remote-control` | Main control group | Main group only | Starts Claude Remote Control and replies with the remote-control URL. |
-| `/remote-control-end` | Main control group | Main group only | Stops the active Claude Remote Control session. |
-| `/chatid` | Telegram | Any Telegram chat with the bot | Replies with the Telegram registration id, name, and chat type. Useful when registering Telegram groups. |
-| `/ping` | Telegram | Any Telegram chat with the bot | Replies with a short online status message. |
+| Command                                           | Where              | Who                            | What It Does                                                                                                                          |
+| ------------------------------------------------- | ------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `/update-nanocrab`                                | Main control group | Main group only                | Starts the host-side updater from the latest NanoCrab GitHub release. Writes logs under `store/updates/` and may restart the service. |
+| `/remote-control`                                 | Main control group | Main group only                | Starts Claude Remote Control and replies with the remote-control URL.                                                                 |
+| `/remote-control-end`                             | Main control group | Main group only                | Stops the active Claude Remote Control session.                                                                                       |
+| `/code`                                           | Main control group | Main group only                | Shows mobile coding-job command help.                                                                                                 |
+| `/code repos`                                     | Main control group | Main group only                | Lists registered coding repositories.                                                                                                 |
+| `/code start owner/repo describe change --pr`     | Main control group | Main group only                | Starts a host-managed coding job from chat. `--pr` requests a draft PR after approvals.                                               |
+| `/code pick owner/repo --labels=bug,autofix --pr` | Main control group | Main group only                | Picks a matching GitHub issue from a registered repo and starts a coding job.                                                         |
+| `/code status [jobId]`                            | Main control group | Main group only                | Shows recent coding jobs or a specific job.                                                                                           |
+| `/code approve\|cancel\|retry\|open-pr jobId`     | Main control group | Main group only                | Controls an existing coding job through the same approval-gated lifecycle as the dashboard.                                           |
+| `/chatid`                                         | Telegram           | Any Telegram chat with the bot | Replies with the Telegram registration id, name, and chat type. Useful when registering Telegram groups.                              |
+| `/ping`                                           | Telegram           | Any Telegram chat with the bot | Replies with a short online status message.                                                                                           |
 
 Most user requests are not hard-coded slash commands. In registered non-main groups, users normally address the bot with the configured trigger, for example:
 
@@ -32,30 +38,30 @@ The default trigger is `@` plus the configured `ASSISTANT_NAME`, for example `@N
 
 Run these from the NanoCrab repository on the host or VPS.
 
-| Command | Purpose |
-| --- | --- |
-| `npm install` or `npm ci` | Install dependencies. Use `npm ci` for release/deployment verification. |
-| `npm run build` | Compile TypeScript and copy the admin frontend into `dist/`. |
-| `npm start` | Start the compiled NanoCrab service from `dist/index.js`. |
-| `npm run dev` | Start NanoCrab from TypeScript with `tsx`. |
-| `npm test` | Run the full Vitest suite. |
-| `npm run typecheck` | Run TypeScript without emitting files. |
-| `npm run lint` | Run ESLint over `src/`. |
-| `npm run lint:fix` | Run ESLint with automatic fixes where possible. |
-| `npm run format` or `npm run format:fix` | Format `src/**/*.ts` with Prettier. |
-| `npm run format:check` | Check formatting without writing changes. |
-| `npm run mock:admin` | Start the sample-data admin dashboard, default `http://127.0.0.1:5173`. |
-| `MOCK_ADMIN_PORT=5180 npm run mock:admin` | Start mock admin on another port. |
-| `npm run mock:admin:build` | Build first, then start the compiled mock dashboard server. |
-| `npm run auth` | Start WhatsApp authentication flow. |
-| `npm run setup -- --step <step>` | Run one setup step through the setup CLI. |
-| `npm run update:nanocrab` | Update from the latest NanoCrab GitHub release from the host shell. |
-| `npm run migrate:nanocrab` | Move old NanoClaw-named local state to NanoCrab paths. |
-| `npm run deploy` | Run the deployment verification/build script. |
-| `npm run mcp:smoke` | Run the generic MCP smoke test. Does not require optional mail providers. |
-| `npm run mcp:smoke:mail` | Run the optional Infomaniak mail smoke test. Requires the Infomaniak MCP preset and credentials. |
-| `./container/build.sh` | Build `nanocrab-agent:latest`. |
-| `./container/build.sh beta1-smoke` | Build a tagged agent image for smoke testing. |
+| Command                                   | Purpose                                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `npm install` or `npm ci`                 | Install dependencies. Use `npm ci` for release/deployment verification.                          |
+| `npm run build`                           | Compile TypeScript and copy the admin frontend into `dist/`.                                     |
+| `npm start`                               | Start the compiled NanoCrab service from `dist/index.js`.                                        |
+| `npm run dev`                             | Start NanoCrab from TypeScript with `tsx`.                                                       |
+| `npm test`                                | Run the full Vitest suite.                                                                       |
+| `npm run typecheck`                       | Run TypeScript without emitting files.                                                           |
+| `npm run lint`                            | Run ESLint over `src/`.                                                                          |
+| `npm run lint:fix`                        | Run ESLint with automatic fixes where possible.                                                  |
+| `npm run format` or `npm run format:fix`  | Format `src/**/*.ts` with Prettier.                                                              |
+| `npm run format:check`                    | Check formatting without writing changes.                                                        |
+| `npm run mock:admin`                      | Start the sample-data admin dashboard, default `http://127.0.0.1:5173`.                          |
+| `MOCK_ADMIN_PORT=5180 npm run mock:admin` | Start mock admin on another port.                                                                |
+| `npm run mock:admin:build`                | Build first, then start the compiled mock dashboard server.                                      |
+| `npm run auth`                            | Start WhatsApp authentication flow.                                                              |
+| `npm run setup -- --step <step>`          | Run one setup step through the setup CLI.                                                        |
+| `npm run update:nanocrab`                 | Update from the latest NanoCrab GitHub release from the host shell.                              |
+| `npm run migrate:nanocrab`                | Move old NanoClaw-named local state to NanoCrab paths.                                           |
+| `npm run deploy`                          | Run the deployment verification/build script.                                                    |
+| `npm run mcp:smoke`                       | Run the generic MCP smoke test. Does not require optional mail providers.                        |
+| `npm run mcp:smoke:mail`                  | Run the optional Infomaniak mail smoke test. Requires the Infomaniak MCP preset and credentials. |
+| `./container/build.sh`                    | Build `nanocrab-agent:latest`.                                                                   |
+| `./container/build.sh beta1-smoke`        | Build a tagged agent image for smoke testing.                                                    |
 
 ### Setup Steps
 
@@ -67,21 +73,21 @@ npx tsx setup/index.ts --step <step> [args...]
 
 Available steps:
 
-| Step | Purpose |
-| --- | --- |
-| `timezone` | Configure local timezone. |
-| `environment` | Check/create the local environment. |
-| `container` | Check container runtime and build agent image. |
-| `groups` | Sync or prepare groups. |
-| `register` | Register channels/groups. |
-| `mounts` | Configure host mount allowlist. |
-| `service` | Install/start launchd, systemd, or fallback service wrapper. |
-| `verify` | Verify installation state. |
-| `provider` | Set default agent provider/model. |
-| `codex-auth` | Import/check Codex OAuth for agent containers. |
-| `admin` | Configure admin credentials and dashboard settings. |
-| `signal-auth` | Register/authenticate Signal. |
-| `whatsapp-auth` | Authenticate WhatsApp via QR or pairing code. |
+| Step            | Purpose                                                      |
+| --------------- | ------------------------------------------------------------ |
+| `timezone`      | Configure local timezone.                                    |
+| `environment`   | Check/create the local environment.                          |
+| `container`     | Check container runtime and build agent image.               |
+| `groups`        | Sync or prepare groups.                                      |
+| `register`      | Register channels/groups.                                    |
+| `mounts`        | Configure host mount allowlist.                              |
+| `service`       | Install/start launchd, systemd, or fallback service wrapper. |
+| `verify`        | Verify installation state.                                   |
+| `provider`      | Set default agent provider/model.                            |
+| `codex-auth`    | Import/check Codex OAuth for agent containers.               |
+| `admin`         | Configure admin credentials and dashboard settings.          |
+| `signal-auth`   | Register/authenticate Signal.                                |
+| `whatsapp-auth` | Authenticate WhatsApp via QR or pairing code.                |
 
 Common examples:
 
@@ -98,62 +104,62 @@ The agent sees these as `mcp__nanocrab__*` tools. You usually do not type these 
 
 ### Messaging And Files
 
-| Tool | What It Does |
-| --- | --- |
+| Tool                          | What It Does                                                              |
+| ----------------------------- | ------------------------------------------------------------------------- |
 | `mcp__nanocrab__send_message` | Sends an immediate progress update or separate reply to the current chat. |
-| `mcp__nanocrab__send_file` | Sends a file from the container filesystem to the current chat. |
+| `mcp__nanocrab__send_file`    | Sends a file from the container filesystem to the current chat.           |
 
 ### Tasks And Groups
 
-| Tool | What It Does |
-| --- | --- |
-| `mcp__nanocrab__schedule_task` | Creates recurring or one-time tasks using cron, interval, or local timestamp schedules. |
-| `mcp__nanocrab__list_tasks` | Lists scheduled tasks. |
-| `mcp__nanocrab__pause_task` | Pauses a scheduled task. |
-| `mcp__nanocrab__resume_task` | Resumes a scheduled task. |
-| `mcp__nanocrab__cancel_task` | Cancels a scheduled task. |
-| `mcp__nanocrab__update_task` | Updates an existing task schedule or prompt. |
-| `mcp__nanocrab__register_group` | Main group only. Registers a channel/group so NanoCrab can work there. |
+| Tool                            | What It Does                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------- |
+| `mcp__nanocrab__schedule_task`  | Creates recurring or one-time tasks using cron, interval, or local timestamp schedules. |
+| `mcp__nanocrab__list_tasks`     | Lists scheduled tasks.                                                                  |
+| `mcp__nanocrab__pause_task`     | Pauses a scheduled task.                                                                |
+| `mcp__nanocrab__resume_task`    | Resumes a scheduled task.                                                               |
+| `mcp__nanocrab__cancel_task`    | Cancels a scheduled task.                                                               |
+| `mcp__nanocrab__update_task`    | Updates an existing task schedule or prompt.                                            |
+| `mcp__nanocrab__register_group` | Main group only. Registers a channel/group so NanoCrab can work there.                  |
 
 ### GitHub And Coding Jobs
 
-| Tool | What It Does |
-| --- | --- |
-| `mcp__nanocrab__register_coding_repo` | Main group only. Registers a GitHub repo for host-managed coding jobs. |
-| `mcp__nanocrab__list_coding_repos` | Main group only. Lists registered coding repos. |
-| `mcp__nanocrab__list_github_issues` | Main group only. Lists open issues from a registered repo. |
-| `mcp__nanocrab__start_coding_job` | Main group only. Starts a dedicated coding job container/workspace. |
-| `mcp__nanocrab__pick_github_issue` | Main group only. Picks a matching GitHub issue and starts a coding job. |
-| `mcp__nanocrab__schedule_github_issue_loop` | Main group only. Schedules recurring issue pickup. |
-| `mcp__nanocrab__list_coding_jobs` | Main group only. Lists recent coding jobs. |
-| `mcp__nanocrab__get_coding_job` | Main group only. Gets full status/output for a coding job. |
-| `mcp__nanocrab__control_coding_job` | Main group only. Approves, cancels, retries, opens PR, or requests revert for a coding job. |
+| Tool                                        | What It Does                                                                                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `mcp__nanocrab__register_coding_repo`       | Main group only. Registers a GitHub repo for host-managed coding jobs.                      |
+| `mcp__nanocrab__list_coding_repos`          | Main group only. Lists registered coding repos.                                             |
+| `mcp__nanocrab__list_github_issues`         | Main group only. Lists open issues from a registered repo.                                  |
+| `mcp__nanocrab__start_coding_job`           | Main group only. Starts a dedicated coding job container/workspace.                         |
+| `mcp__nanocrab__pick_github_issue`          | Main group only. Picks a matching GitHub issue and starts a coding job.                     |
+| `mcp__nanocrab__schedule_github_issue_loop` | Main group only. Schedules recurring issue pickup.                                          |
+| `mcp__nanocrab__list_coding_jobs`           | Main group only. Lists recent coding jobs.                                                  |
+| `mcp__nanocrab__get_coding_job`             | Main group only. Gets full status/output for a coding job.                                  |
+| `mcp__nanocrab__control_coding_job`         | Main group only. Approves, cancels, retries, opens PR, or requests revert for a coding job. |
 
 ### Memory, Journal, And Skills
 
-| Tool | What It Does |
-| --- | --- |
-| `mcp__nanocrab__propose_memory` | Proposes a structured long-term memory for owner review. |
-| `mcp__nanocrab__list_memories` | Main group only. Lists memory records and proposals. |
-| `mcp__nanocrab__approve_memory` | Main group only. Approves a memory and refreshes generated memory context. |
-| `mcp__nanocrab__reject_memory` | Main group only. Rejects a memory proposal. |
-| `mcp__nanocrab__record_journal_event` | Records a notable event for later search. |
-| `mcp__nanocrab__search_journal_events` | Searches journal events, for questions like "when did that happen?" |
-| `mcp__nanocrab__propose_skill_draft` | Proposes a provider-neutral `SKILL.md` draft for approval. |
-| `mcp__nanocrab__list_skill_drafts` | Main group only. Lists pending, approved, or rejected skill drafts. |
-| `mcp__nanocrab__approve_skill_draft` | Main group only. Installs an approved skill into `container/skills`. |
-| `mcp__nanocrab__reject_skill_draft` | Main group only. Rejects a skill draft. |
+| Tool                                   | What It Does                                                               |
+| -------------------------------------- | -------------------------------------------------------------------------- |
+| `mcp__nanocrab__propose_memory`        | Proposes a structured long-term memory for owner review.                   |
+| `mcp__nanocrab__list_memories`         | Main group only. Lists memory records and proposals.                       |
+| `mcp__nanocrab__approve_memory`        | Main group only. Approves a memory and refreshes generated memory context. |
+| `mcp__nanocrab__reject_memory`         | Main group only. Rejects a memory proposal.                                |
+| `mcp__nanocrab__record_journal_event`  | Records a notable event for later search.                                  |
+| `mcp__nanocrab__search_journal_events` | Searches journal events, for questions like "when did that happen?"        |
+| `mcp__nanocrab__propose_skill_draft`   | Proposes a provider-neutral `SKILL.md` draft for approval.                 |
+| `mcp__nanocrab__list_skill_drafts`     | Main group only. Lists pending, approved, or rejected skill drafts.        |
+| `mcp__nanocrab__approve_skill_draft`   | Main group only. Installs an approved skill into `container/skills`.       |
+| `mcp__nanocrab__reject_skill_draft`    | Main group only. Rejects a skill draft.                                    |
 
 ### Reports, Research, And Artifacts
 
-| Tool | What It Does |
-| --- | --- |
-| `mcp__nanocrab__request_report` | Requests a report/document job with sources and output formats. |
-| `mcp__nanocrab__list_report_jobs` | Main group only. Lists report/document jobs. |
-| `mcp__nanocrab__request_research` | Requests a host-managed Playwright-backed research job. |
-| `mcp__nanocrab__list_research_jobs` | Main group only. Lists research jobs. |
-| `mcp__nanocrab__create_artifact` | Creates a Markdown, HTML, CSV, or text artifact in the group workspace. |
-| `mcp__nanocrab__list_artifacts` | Lists artifacts in the group workspace. |
+| Tool                                | What It Does                                                            |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| `mcp__nanocrab__request_report`     | Requests a report/document job with sources and output formats.         |
+| `mcp__nanocrab__list_report_jobs`   | Main group only. Lists report/document jobs.                            |
+| `mcp__nanocrab__request_research`   | Requests a host-managed Playwright-backed research job.                 |
+| `mcp__nanocrab__list_research_jobs` | Main group only. Lists research jobs.                                   |
+| `mcp__nanocrab__create_artifact`    | Creates a Markdown, HTML, CSV, or text artifact in the group workspace. |
+| `mcp__nanocrab__list_artifacts`     | Lists artifacts in the group workspace.                                 |
 
 ## Useful Natural-Language Examples
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,7 +183,7 @@ Goal: work with GitHub repos and produce PRs while the owner is on the go.
   - DONE: "Investigate" creates a read-only plan stage before implementation.
   - DONE: "Implement" requires approval and creates commits.
   - DONE: "Open PR" requires approval before host-side GitHub mutation.
-  - NEXT: mobile chat commands for coding jobs.
+  - DONE: mobile `/code` chat commands can list repos/jobs, start jobs, pick issues, and approve/cancel/retry/open PRs.
 - Dashboard views:
   - DONE: active/recent coding jobs and output logs
   - DONE: PR links when jobs create PRs

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,18 @@ import {
 } from './admin/websocket.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { startProbeScheduler } from './probe-scheduler.js';
+import {
+  approveCodingJob,
+  cancelCodingJob,
+  getCodingJob,
+  loadCodingJobs,
+  loadCodingRepos,
+  openCodingJobPr,
+  pickGitHubIssue,
+  retryCodingJob,
+  startCodingJob,
+} from './coding-jobs.js';
+import { handleMobileCodingCommand } from './mobile-coding-commands.js';
 import { getAllProviders } from './providers/index.js';
 import { liveProbeService } from './providers/live-probe.js';
 import {
@@ -935,6 +947,35 @@ async function main(): Promise<void> {
     }
   }
 
+  async function handleMobileCodeCommand(
+    chatJid: string,
+    msg: NewMessage,
+  ): Promise<boolean> {
+    const channel = findChannel(channels, chatJid);
+    if (!channel) return false;
+    return handleMobileCodingCommand({
+      text: msg.content,
+      chatJid,
+      sender: msg.sender,
+      group: registeredGroups[chatJid],
+      sendMessage: (jid, text) => channel.sendMessage(jid, text),
+      deps: {
+        startCodingJob,
+        pickGitHubIssue,
+        loadCodingRepos,
+        loadCodingJobs,
+        getCodingJob,
+        controlCodingJob: async (action, jobId, actor) => {
+          if (action === 'approve') return approveCodingJob(jobId, actor);
+          if (action === 'cancel') return cancelCodingJob(jobId, actor);
+          if (action === 'retry') return retryCodingJob(jobId, actor);
+          if (action === 'open-pr') return openCodingJobPr(jobId, actor);
+          throw new Error(`Unsupported coding action: ${action}`);
+        },
+      },
+    });
+  }
+
   // Channel callbacks (shared by all channels)
   const channelOpts = {
     onMessage: (chatJid: string, msg: NewMessage) => {
@@ -968,6 +1009,12 @@ async function main(): Promise<void> {
       if (trimmed === '/update-nanocrab') {
         handleNanoCrabUpdate(chatJid, msg).catch((err) =>
           logger.error({ err, chatJid }, 'NanoCrab update command error'),
+        );
+        return;
+      }
+      if (trimmed === '/code' || trimmed.startsWith('/code ')) {
+        handleMobileCodeCommand(chatJid, msg).catch((err) =>
+          logger.error({ err, chatJid }, 'Mobile coding command error'),
         );
         return;
       }

--- a/src/mobile-coding-commands.test.ts
+++ b/src/mobile-coding-commands.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  handleMobileCodingCommand,
+  type MobileCodingJobSummary,
+} from './mobile-coding-commands.js';
+
+function jobSummary(
+  overrides: Partial<MobileCodingJobSummary> = {},
+): MobileCodingJobSummary {
+  return {
+    id: 'job-1',
+    repo: 'owner/repo',
+    status: 'queued',
+    branch: 'nanocrab/job-1',
+    ...overrides,
+  };
+}
+
+describe('mobile coding commands', () => {
+  it('starts a coding job from a main-group /code start command', async () => {
+    const sendMessage = vi.fn();
+    const startCodingJob = vi.fn(async () =>
+      jobSummary({
+        id: 'job-1',
+        branch: 'nanocrab/mobile-job-1',
+      }),
+    );
+
+    const handled = await handleMobileCodingCommand({
+      text: '/code start owner/repo Fix the settings page on mobile --pr',
+      chatJid: 'wa:main',
+      sender: 'Henrik',
+      group: { isMain: true, folder: 'main' },
+      sendMessage,
+      deps: {
+        startCodingJob,
+        pickGitHubIssue: vi.fn(),
+        loadCodingRepos: vi.fn(),
+        loadCodingJobs: vi.fn(),
+        getCodingJob: vi.fn(),
+        controlCodingJob: vi.fn(),
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(startCodingJob).toHaveBeenCalledWith({
+      repo: 'owner/repo',
+      prompt: 'Fix the settings page on mobile',
+      requestedBy: 'mobile:wa:main:Henrik',
+      createPr: true,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wa:main',
+      expect.stringContaining('Coding job queued: job-1'),
+    );
+  });
+
+  it('rejects coding commands outside the main control group', async () => {
+    const sendMessage = vi.fn();
+    const startCodingJob = vi.fn();
+
+    const handled = await handleMobileCodingCommand({
+      text: '/code start owner/repo Try to mutate a repo',
+      chatJid: 'wa:side',
+      sender: 'Scout',
+      group: { isMain: false, folder: 'side' },
+      sendMessage,
+      deps: {
+        startCodingJob,
+        pickGitHubIssue: vi.fn(),
+        loadCodingRepos: vi.fn(),
+        loadCodingJobs: vi.fn(),
+        getCodingJob: vi.fn(),
+        controlCodingJob: vi.fn(),
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(startCodingJob).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wa:side',
+      expect.stringContaining('main control group'),
+    );
+  });
+
+  it('picks a GitHub issue and starts a coding job from mobile', async () => {
+    const sendMessage = vi.fn();
+    const pickGitHubIssue = vi.fn(async () => ({
+      issue: { number: 42, title: 'Fix mobile controls' },
+      job: jobSummary({
+        id: 'job-42',
+        branch: 'nanocrab/issue-42',
+      }),
+    }));
+
+    await handleMobileCodingCommand({
+      text: '/code pick owner/repo --labels=bug,mobile --pr',
+      chatJid: 'wa:main',
+      sender: 'Henrik',
+      group: { isMain: true, folder: 'main' },
+      sendMessage,
+      deps: {
+        startCodingJob: vi.fn(),
+        pickGitHubIssue,
+        loadCodingRepos: vi.fn(),
+        loadCodingJobs: vi.fn(),
+        getCodingJob: vi.fn(),
+        controlCodingJob: vi.fn(),
+      },
+    });
+
+    expect(pickGitHubIssue).toHaveBeenCalledWith({
+      repo: 'owner/repo',
+      labels: ['bug', 'mobile'],
+      requestedBy: 'mobile:wa:main:Henrik',
+      createPr: true,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wa:main',
+      expect.stringContaining('Picked issue #42'),
+    );
+  });
+
+  it('lists recent coding jobs and controls approval from mobile', async () => {
+    const sendMessage = vi.fn();
+    const controlCodingJob = vi.fn(async () =>
+      jobSummary({
+        id: 'job-1',
+        status: 'implement',
+      }),
+    );
+    const deps = {
+      startCodingJob: vi.fn(),
+      pickGitHubIssue: vi.fn(),
+      loadCodingRepos: vi.fn(),
+      loadCodingJobs: vi.fn(() => [
+        jobSummary({
+          id: 'job-1',
+          status: 'await_approval',
+        }),
+      ]),
+      getCodingJob: vi.fn(),
+      controlCodingJob,
+    };
+
+    await handleMobileCodingCommand({
+      text: '/code status',
+      chatJid: 'wa:main',
+      sender: 'Henrik',
+      group: { isMain: true, folder: 'main' },
+      sendMessage,
+      deps,
+    });
+    await handleMobileCodingCommand({
+      text: '/code approve job-1',
+      chatJid: 'wa:main',
+      sender: 'Henrik',
+      group: { isMain: true, folder: 'main' },
+      sendMessage,
+      deps,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wa:main',
+      expect.stringContaining('job-1 owner/repo await_approval'),
+    );
+    expect(controlCodingJob).toHaveBeenCalledWith(
+      'approve',
+      'job-1',
+      'mobile:wa:main:Henrik',
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      'wa:main',
+      expect.stringContaining('Coding job updated: job-1'),
+    );
+  });
+});

--- a/src/mobile-coding-commands.ts
+++ b/src/mobile-coding-commands.ts
@@ -1,0 +1,212 @@
+import type { CodingJob, CodingRepo } from './coding-jobs.js';
+
+export type MobileCodingJobSummary = Pick<
+  CodingJob,
+  'id' | 'repo' | 'status' | 'branch'
+>;
+
+export interface MobileGitHubIssueSummary {
+  number: number;
+  title: string;
+}
+
+export interface MobileCodingCommandGroup {
+  isMain?: boolean;
+  folder?: string;
+}
+
+export interface MobileCodingCommandDeps {
+  startCodingJob(input: {
+    repo: string;
+    prompt?: string;
+    requestedBy: string;
+    createPr?: boolean;
+  }): Promise<MobileCodingJobSummary>;
+  pickGitHubIssue(input: {
+    repo: string;
+    labels?: string[];
+    requestedBy: string;
+    createPr?: boolean;
+  }): Promise<{
+    issue: MobileGitHubIssueSummary;
+    job: MobileCodingJobSummary;
+  } | null>;
+  loadCodingRepos(): CodingRepo[];
+  loadCodingJobs(): MobileCodingJobSummary[];
+  getCodingJob(jobId: string): MobileCodingJobSummary | undefined;
+  controlCodingJob(
+    action: string,
+    jobId: string,
+    actor: string,
+  ): Promise<MobileCodingJobSummary> | MobileCodingJobSummary;
+}
+
+export interface HandleMobileCodingCommandInput {
+  text: string;
+  chatJid: string;
+  sender: string;
+  group?: MobileCodingCommandGroup;
+  sendMessage(chatJid: string, text: string): Promise<void> | void;
+  deps: MobileCodingCommandDeps;
+}
+
+function splitArgs(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function parseFlags(args: string[]) {
+  const positional: string[] = [];
+  const flags = new Map<string, string | true>();
+  for (const arg of args) {
+    if (arg === '--pr') flags.set('pr', true);
+    else if (arg.startsWith('--labels=')) flags.set('labels', arg.slice(9));
+    else positional.push(arg);
+  }
+  return { positional, flags };
+}
+
+function helpText() {
+  return [
+    'Mobile coding commands:',
+    '/code repos',
+    '/code start owner/repo describe the change --pr',
+    '/code pick owner/repo --labels=bug,autofix --pr',
+    '/code status [jobId]',
+    '/code approve|cancel|retry|open-pr jobId',
+  ].join('\n');
+}
+
+function formatJob(job: MobileCodingJobSummary) {
+  return `${job.id} ${job.repo} ${job.status} ${job.branch || ''}`.trim();
+}
+
+export async function handleMobileCodingCommand(
+  input: HandleMobileCodingCommandInput,
+): Promise<boolean> {
+  const trimmed = input.text.trim();
+  if (trimmed !== '/code' && !trimmed.startsWith('/code ')) return false;
+  if (!input.group?.isMain) {
+    await input.sendMessage(
+      input.chatJid,
+      'Coding commands are only available in the main control group.',
+    );
+    return true;
+  }
+
+  const args = splitArgs(trimmed).slice(1);
+  const command = args.shift() || 'help';
+  const actor = `mobile:${input.chatJid}:${input.sender}`;
+
+  try {
+    if (command === 'help') {
+      await input.sendMessage(input.chatJid, helpText());
+      return true;
+    }
+    if (command === 'start') {
+      const { positional, flags } = parseFlags(args);
+      const repo = positional.shift();
+      const prompt = positional.join(' ').trim();
+      if (!repo || !prompt) {
+        await input.sendMessage(
+          input.chatJid,
+          'Usage: /code start owner/repo describe the change --pr',
+        );
+        return true;
+      }
+      const job = await input.deps.startCodingJob({
+        repo,
+        prompt,
+        requestedBy: actor,
+        createPr: flags.has('pr') || undefined,
+      });
+      await input.sendMessage(
+        input.chatJid,
+        `Coding job queued: ${job.id}\nRepo: ${job.repo}\nStatus: ${job.status}\nBranch: ${job.branch}`,
+      );
+      return true;
+    }
+    if (command === 'pick') {
+      const { positional, flags } = parseFlags(args);
+      const repo = positional.shift();
+      if (!repo) {
+        await input.sendMessage(
+          input.chatJid,
+          'Usage: /code pick owner/repo --labels=bug,autofix --pr',
+        );
+        return true;
+      }
+      const labels =
+        typeof flags.get('labels') === 'string'
+          ? String(flags.get('labels'))
+              .split(',')
+              .map((label) => label.trim())
+              .filter(Boolean)
+          : undefined;
+      const picked = await input.deps.pickGitHubIssue({
+        repo,
+        labels,
+        requestedBy: actor,
+        createPr: flags.has('pr') || undefined,
+      });
+      if (!picked) {
+        await input.sendMessage(
+          input.chatJid,
+          `No matching issues found for ${repo}.`,
+        );
+        return true;
+      }
+      await input.sendMessage(
+        input.chatJid,
+        `Picked issue #${picked.issue.number}: ${picked.issue.title}\nCoding job queued: ${picked.job.id}\nStatus: ${picked.job.status}`,
+      );
+      return true;
+    }
+    if (command === 'repos') {
+      const repos = input.deps.loadCodingRepos();
+      await input.sendMessage(
+        input.chatJid,
+        repos.length
+          ? repos
+              .map((repo) => `${repo.fullName} (${repo.defaultBranch})`)
+              .join('\n')
+          : 'No coding repositories are registered.',
+      );
+      return true;
+    }
+    if (command === 'status') {
+      const jobId = args[0];
+      const jobs = jobId
+        ? [input.deps.getCodingJob(jobId)].filter(Boolean)
+        : input.deps.loadCodingJobs().slice(0, 5);
+      await input.sendMessage(
+        input.chatJid,
+        jobs.length
+          ? jobs
+              .map((job) => formatJob(job as MobileCodingJobSummary))
+              .join('\n')
+          : 'No coding jobs found.',
+      );
+      return true;
+    }
+    if (['approve', 'cancel', 'retry', 'open-pr'].includes(command)) {
+      const jobId = args[0];
+      if (!jobId) {
+        await input.sendMessage(input.chatJid, `Usage: /code ${command} jobId`);
+        return true;
+      }
+      const job = await input.deps.controlCodingJob(command, jobId, actor);
+      await input.sendMessage(
+        input.chatJid,
+        `Coding job updated: ${formatJob(job)}`,
+      );
+      return true;
+    }
+
+    await input.sendMessage(input.chatJid, helpText());
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await input.sendMessage(input.chatJid, `Coding command failed: ${message}`);
+    return true;
+  }
+}


### PR DESCRIPTION
Fixes #30

## Summary
- add a host-side /code mobile command handler for coding repos, jobs, issue pickup, status, and approval controls
- intercept /code messages from channel callbacks and route them to the existing coding-job lifecycle
- document the mobile chat commands and mark the roadmap item complete

## Verification
- rtk mise exec node@22 -- npx vitest run src/mobile-coding-commands.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- rtk mise exec node@22 -- npm run format:check
- rtk git diff --check