### PR TITLE
Add skill version history and rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ success responses and do not mutate live files or services.
 
 - **Memory v2** — agents can propose structured memories with sensitivity, source, stale, and contradiction metadata; the dashboard reviews what becomes active.
 - **Journal v2** — agents can record notable events, extract daily/weekly summaries, and answer natural questions like "when was that fleet crash?" with cited events and summaries.
-- **Skill Factory v2** — agents can propose provider-neutral `SKILL.md` drafts with version/provenance metadata, validation, diff review, and approval before installation into `container/skills`.
+- **Skill Factory v2** — agents can propose provider-neutral `SKILL.md` drafts with version/provenance metadata, validation, diff review, and approval before installation into `container/skills`. Installed skills keep version snapshots with install state, dashboard diffs, and rollback controls.
 - **Bundled Default Skills** — NanoCrab ships with generic skills for memory curation, journaling, task planning, reports, GitHub issue work, code review, release management, email assistance, browser research, documents, images, and capabilities/status.
 - **Suggested Skills** — the dashboard Skills page highlights reusable workflow candidates from recent history, such as private operations planning or dashboard design review. Suggestions become inactive drafts first and still require approval.
 - **Skill Registry** — skills can be enabled/disabled and scoped to all agents, main-only, or channel agents. Visibility can be shared, private, or system. Agents can also call `list_skills` and `search_skills` to find skills related to a user request.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,6 +151,7 @@ Let the agent create skills, but never install them silently.
 - DONE: Require owner/admin approval before installing into `container/skills`.
 - After approval, rebuild/sync skills so the skill becomes shared across all channels.
 - DONE: Draft metadata tracks proposer, validation state, installed version, review/install time, provenance, and diff review data.
+- DONE: Installed skills keep version snapshots, install-state badges, dashboard diff review, and admin rollback controls.
 
 ### Journal v2
 

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -1010,6 +1010,70 @@ const repos = [
   { name: 'auroradocs', path: '/workspace/repos/auroradocs', readonly: true },
 ];
 
+function mockSkillInstallState(skillPath: string) {
+  if (skillPath === 'operation-planning') {
+    return {
+      status: 'modified',
+      skillPath,
+      exists: true,
+      currentSha256: 'mock-current-operation-planning',
+      currentVersion: null,
+      latestVersion: 2,
+      latestSha256: 'mock-history-operation-planning-v2',
+      updatedAt: iso(32),
+    };
+  }
+  return {
+    status: skillPath === 'docx-generation' ? 'untracked' : 'installed',
+    skillPath,
+    exists: true,
+    currentSha256: `mock-history-${skillPath}-v2`,
+    currentVersion: skillPath === 'docx-generation' ? null : 2,
+    latestVersion: skillPath === 'docx-generation' ? null : 2,
+    latestSha256:
+      skillPath === 'docx-generation' ? null : `mock-history-${skillPath}-v2`,
+    updatedAt: skillPath === 'docx-generation' ? null : iso(32),
+  };
+}
+
+function mockSkillVersions(skillPath: string) {
+  if (skillPath === 'docx-generation') {
+    return {
+      installState: mockSkillInstallState(skillPath),
+      versions: [],
+    };
+  }
+  return {
+    installState: mockSkillInstallState(skillPath),
+    versions: [
+      {
+        id: `skill-version-${skillPath}-2`,
+        skillPath,
+        version: 2,
+        action: skillPath === 'operation-planning' ? 'update' : 'install',
+        actor: 'dashboard',
+        timestamp: iso(32),
+        sha256: `mock-history-${skillPath}-v2`,
+        bytes: 1260,
+        note: 'Refined triggers and safety notes for mock preview.',
+        contentPath: `/mock/store/skill-versions/${skillPath}/v0002-SKILL.md`,
+      },
+      {
+        id: `skill-version-${skillPath}-1`,
+        skillPath,
+        version: 1,
+        action: 'install',
+        actor: 'skill-factory',
+        timestamp: iso(90),
+        sha256: `mock-history-${skillPath}-v1`,
+        bytes: 1048,
+        note: 'Initial approved install.',
+        contentPath: `/mock/store/skill-versions/${skillPath}/v0001-SKILL.md`,
+      },
+    ],
+  };
+}
+
 const skills = [
   {
     name: 'capabilities',
@@ -1140,6 +1204,7 @@ const skills = [
   triggers: skill.name.split('-'),
   examples: [],
   requiredTools: [],
+  installState: mockSkillInstallState(skill.path),
   ...skill,
 }));
 
@@ -3003,6 +3068,10 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
         '---\nname: operation-briefing\ndescription: Produce concise operation briefings from journal events, orders, and scout reports.\n---\n\n# Operation Briefing\n\nUse journal events and approved orders to prepare a concise brief with confirmed facts, open questions, and next actions.\n',
     };
   }
+  const skillVersionsMatch = pathname.match(/^\/skills\/([^/]+)\/versions$/);
+  if (skillVersionsMatch) {
+    return mockSkillVersions(decodeURIComponent(skillVersionsMatch[1]));
+  }
   if (pathname.startsWith('/skills/')) {
     const skill = skills.find((s) => s.path === pathname.split('/')[2]);
     return {
@@ -4213,6 +4282,22 @@ export function handleMockApi(req: Request, res: Response): void {
       .send(
         '# Mock report artifact\n\nThis mock download does not read live files.\n',
       );
+    return;
+  }
+  if (pathname.match(/^\/skills\/[^/]+\/versions\/\d+\/diff$/)) {
+    res.type('text/plain').send(`--- v1/mock-skill/SKILL.md
++++ installed/mock-skill/SKILL.md
+ ---
+ name: mock-skill
+-description: Initial skill instructions.
++description: Refined skill instructions with safety notes.
+ ---
+
+ # Mock Skill
+
+-Use this skill for basic mock workflows.
++Use this skill for mock workflows with explicit approval notes.
+`);
     return;
   }
 

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -3643,6 +3643,7 @@ async function renderSkills(el, options = {}) {
                 <span class="badge ${s.enabled ? 'badge-success' : 'badge-muted'}">${s.enabled ? 'Enabled' : 'Disabled'}</span>
                 <span class="badge badge-info">${esc(s.scope || 'all')}</span>
                 <span class="badge ${s.visibility === 'private' ? 'badge-warning' : 'badge-muted'}">${esc(s.visibility || 'shared')}</span>
+                ${s.installState ? `<span class="badge ${s.installState.status === 'installed' ? 'badge-success' : s.installState.status === 'modified' ? 'badge-warning' : s.installState.status === 'missing' ? 'badge-error' : 'badge-muted'}">${esc(s.installState.status)}</span>` : ''}
                 ${s.riskLevel ? `<span class="badge ${s.riskLevel === 'high' ? 'badge-error' : s.riskLevel === 'medium' ? 'badge-warning' : 'badge-muted'}">risk ${esc(s.riskLevel)}</span>` : ''}
               </div>
               <div style="font-size:12px;color:var(--text-muted);margin-top:2px;overflow:hidden;text-overflow:ellipsis">${esc(s.description || 'No description')}</div>
@@ -3665,6 +3666,7 @@ async function renderSkills(el, options = {}) {
                 <option value="system" ${s.visibility === 'system' ? 'selected' : ''}>System</option>
               </select>
               <button class="btn btn-sm btn-ghost" onclick="editSkill('${esc(s.path)}')">Edit</button>
+              <button class="btn btn-sm btn-ghost" onclick="viewSkillVersions('${esc(s.path)}')">History</button>
               ${cat !== 'core' ? `<button class="btn btn-sm btn-danger" onclick="deleteSkill('${esc(s.path)}',this)">Delete</button>` : ''}
             </div>
           </div>`,
@@ -3674,6 +3676,7 @@ async function renderSkills(el, options = {}) {
       })
       .join('')}
     <div id="skill-editor" style="display:none"></div>
+    <div id="skill-version-viewer" style="display:none"></div>
     <div id="skill-draft-viewer" style="display:none"></div>
     ${options.embedded ? '' : '<div id="skills-page-timeline"></div>'}`;
 
@@ -3847,6 +3850,79 @@ window.saveSkill = async (skillPath) => {
     toast(r.message || 'Saved', 'success');
     document.getElementById('skill-editor').style.display = 'none';
   } else toast(r.error || 'Failed', 'error');
+};
+
+window.viewSkillVersions = async (skillPath) => {
+  const data = await api(`/skills/${encodeURIComponent(skillPath)}/versions`);
+  const viewer = document.getElementById('skill-version-viewer');
+  const state = data.installState || {};
+  viewer.style.display = 'block';
+  viewer.innerHTML = `
+    <div class="card" style="margin-top:16px">
+      <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;margin-bottom:12px">
+        <div class="card-title" style="margin:0">History: ${esc(skillPath)}/SKILL.md</div>
+        <button class="btn btn-sm btn-ghost" onclick="document.getElementById('skill-version-viewer').style.display='none'">Close</button>
+      </div>
+      <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px">
+        <span class="badge badge-muted">${esc(state.status || 'unknown')}</span>
+        <span class="badge badge-info">current ${esc(String(state.currentVersion || 'untracked'))}</span>
+        <span class="badge badge-muted">latest ${esc(String(state.latestVersion || 'none'))}</span>
+      </div>
+      ${
+        data.versions && data.versions.length
+          ? data.versions
+              .map(
+                (version) => `
+        <div class="channel-card" style="align-items:flex-start">
+          <div style="flex:1;min-width:0">
+            <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+              <span style="font-weight:600;color:var(--text)">v${esc(String(version.version))}</span>
+              <span class="badge badge-info">${esc(version.action)}</span>
+              ${version.restoredFromVersion ? `<span class="badge badge-warning">from v${esc(String(version.restoredFromVersion))}</span>` : ''}
+              <span class="badge badge-muted">${esc(String(version.bytes || 0))} bytes</span>
+            </div>
+            <div style="font-size:11px;color:var(--text-muted);margin-top:4px">${esc(version.actor || 'unknown')} &middot; ${formatTime(version.timestamp)} &middot; ${esc((version.sha256 || '').slice(0, 12))}</div>
+            ${version.note ? `<div style="font-size:12px;color:var(--text-muted);margin-top:4px">${esc(version.note)}</div>` : ''}
+          </div>
+          <div style="display:flex;gap:5px;flex-wrap:wrap">
+            <button class="btn btn-sm btn-ghost" onclick="viewSkillVersionDiff('${esc(skillPath)}',${Number(version.version)})">Diff</button>
+            <button class="btn btn-sm btn-ghost" onclick="rollbackSkillVersion('${esc(skillPath)}',${Number(version.version)},this)">Rollback</button>
+          </div>
+        </div>`,
+              )
+              .join('')
+          : '<div class="empty" style="padding:12px">No versions recorded yet</div>'
+      }
+      <pre id="skill-version-diff" class="log-viewer" style="display:none;margin-top:12px;max-height:360px;white-space:pre-wrap"></pre>
+    </div>`;
+  viewer.scrollIntoView({ behavior: 'smooth' });
+};
+
+window.viewSkillVersionDiff = async (skillPath, version) => {
+  const res = await fetch(
+    `/api/skills/${encodeURIComponent(skillPath)}/versions/${encodeURIComponent(version)}/diff`,
+    { headers: { Accept: 'text/plain' } },
+  );
+  const diff = await res.text();
+  const target = document.getElementById('skill-version-diff');
+  target.style.display = 'block';
+  target.textContent = diff;
+};
+
+window.rollbackSkillVersion = async (skillPath, version, btnEl) => {
+  inlineConfirm(btnEl, `Rollback "${skillPath}" to v${version}?`, async () => {
+    const r = await api(
+      `/skills/${encodeURIComponent(skillPath)}/versions/${encodeURIComponent(version)}/rollback`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ actor: 'dashboard' }),
+      },
+    );
+    if (r.ok) {
+      toast(r.message || 'Rolled back', 'success');
+      await viewSkillVersions(skillPath);
+    } else toast(r.error || 'Failed', 'error');
+  });
 };
 
 window.deleteSkill = async (skillPath, btnEl) => {

--- a/src/admin/routes/skills.ts
+++ b/src/admin/routes/skills.ts
@@ -33,6 +33,13 @@ import {
 import { getAllTasks } from '../../db.js';
 import { findSkillWorthyJournalPatterns } from '../../journal-store.js';
 import { listMemoryProvenanceTimeline } from '../../memory-store.js';
+import {
+  getSkillInstallState,
+  getSkillVersionDiff,
+  listSkillVersions,
+  recordSkillVersion,
+  rollbackSkillVersion,
+} from '../../skill-versions.js';
 
 const router = Router();
 const PROJECT_ROOT = process.cwd();
@@ -344,6 +351,91 @@ router.get('/timeline', (req: Request, res: Response) => {
   res.json(buildProvenanceTimeline(timelineLimit(req.query.limit)));
 });
 
+router.get('/:skillPath/versions', (req: Request, res: Response) => {
+  try {
+    const skillPath = req.params.skillPath as string;
+    res.json({
+      installState: getSkillInstallState(skillPath),
+      versions: listSkillVersions(skillPath),
+    });
+  } catch (err) {
+    res.status(400).json({
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
+router.get(
+  '/:skillPath/versions/:version/diff',
+  (req: Request, res: Response) => {
+    try {
+      const fromVersion = Number(req.params.version);
+      const toVersion =
+        req.query.to === undefined ? undefined : Number(req.query.to);
+      if (!Number.isInteger(fromVersion) || fromVersion < 1) {
+        res.status(400).json({ error: 'Invalid version' });
+        return;
+      }
+      if (
+        toVersion !== undefined &&
+        (!Number.isInteger(toVersion) || toVersion < 1)
+      ) {
+        res.status(400).json({ error: 'Invalid target version' });
+        return;
+      }
+      res
+        .type('text/plain')
+        .send(
+          getSkillVersionDiff(
+            req.params.skillPath as string,
+            fromVersion,
+            toVersion,
+          ),
+        );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res
+        .status(message.includes('not found') ? 404 : 400)
+        .json({ error: message });
+    }
+  },
+);
+
+router.post(
+  '/:skillPath/versions/:version/rollback',
+  requireRole('admin'),
+  (req: Request, res: Response) => {
+    try {
+      const version = Number(req.params.version);
+      if (!Number.isInteger(version) || version < 1) {
+        res.status(400).json({ error: 'Invalid version' });
+        return;
+      }
+      const entry = rollbackSkillVersion({
+        skillPath: req.params.skillPath as string,
+        version,
+        actor: String(req.body?.actor || 'dashboard'),
+      });
+      auditLog(
+        req,
+        'skill_rollback',
+        `${req.params.skillPath}@${version} -> ${entry.version}`,
+      );
+      res.json({
+        ok: true,
+        version: entry,
+        installState: getSkillInstallState(req.params.skillPath as string),
+        message: 'Skill rolled back. Rebuild container to apply.',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res
+        .status(message.includes('not found') ? 404 : 400)
+        .json({ error: message });
+    }
+  },
+);
+
 router.post(
   '/suggestions/:id/approve',
   requireRole('admin'),
@@ -510,6 +602,12 @@ router.post('/', requireRole('admin'), (req: Request, res: Response) => {
 
   fs.mkdirSync(skillDir, { recursive: true });
   fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillMd);
+  recordSkillVersion({
+    skillPath: folderName,
+    actor: 'dashboard',
+    action: 'create',
+    note: 'Installed directly from dashboard',
+  });
 
   auditLog(req, 'skill_created', folderName);
   logger.info({ skillName: folderName }, 'Container skill created');
@@ -550,6 +648,12 @@ router.put(
     }
 
     fs.writeFileSync(skillMd, content);
+    recordSkillVersion({
+      skillPath,
+      actor: 'dashboard',
+      action: 'update',
+      note: 'Updated from dashboard editor',
+    });
     auditLog(req, 'skill_updated', skillPath);
     res.json({
       ok: true,
@@ -575,6 +679,12 @@ router.delete(
       return;
     }
 
+    recordSkillVersion({
+      skillPath,
+      actor: 'dashboard',
+      action: 'delete',
+      note: 'Snapshot before dashboard delete',
+    });
     fs.rmSync(skillDir, { recursive: true, force: true });
     auditLog(req, 'skill_deleted', skillPath);
     logger.info({ skillName: skillPath }, 'Container skill deleted');

--- a/src/skill-factory.ts
+++ b/src/skill-factory.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { CONTAINER_SKILLS_DIR, STORE_DIR } from './config.js';
+import { recordSkillVersion } from './skill-versions.js';
 
 export type SkillDraftStatus = 'pending' | 'approved' | 'rejected';
 export type SkillSuggestionStatus = 'pending' | 'approved' | 'rejected';
@@ -429,6 +430,12 @@ export function approveSkillDraft(id: string): SkillDraft {
   const installDir = path.join(CONTAINER_SKILLS_DIR, draft.name);
   fs.mkdirSync(installDir, { recursive: true });
   fs.copyFileSync(skillPath(id), path.join(installDir, 'SKILL.md'));
+  recordSkillVersion({
+    skillPath: draft.name,
+    actor: 'skill-factory',
+    action: 'install',
+    note: `Approved draft ${draft.id}`,
+  });
   draft.status = 'approved';
   draft.reviewedAt = new Date().toISOString();
   draft.installDir = installDir;

--- a/src/skill-registry.ts
+++ b/src/skill-registry.ts
@@ -5,6 +5,10 @@ import crypto from 'crypto';
 
 import { CONTAINER_SKILLS_DIR, DATA_DIR, STORE_DIR } from './config.js';
 import { canUseSkill, type AgentBoundary } from './agent-boundaries.js';
+import {
+  getSkillInstallState,
+  type SkillInstallState,
+} from './skill-versions.js';
 
 export type SkillScope = 'all' | 'main' | 'channels';
 export type SkillVisibility = 'shared' | 'private' | 'system';
@@ -27,6 +31,7 @@ export interface SkillRegistryEntry {
   examples: string[];
   riskLevel: 'low' | 'medium' | 'high';
   requiredTools: string[];
+  installState?: SkillInstallState;
 }
 
 export interface SkillMatch extends SkillRegistryEntry {
@@ -326,6 +331,7 @@ export function listSkillRegistry(): SkillRegistryEntry[] {
           examples: splitList(fm.examples),
           riskLevel,
           requiredTools: splitList(fm['required-tools'] || fm['allowed-tools']),
+          installState: getSkillInstallState(dir.name),
         } satisfies SkillRegistryEntry;
       })
       .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/skill-versions.test.ts
+++ b/src/skill-versions.test.ts
@@ -1,0 +1,125 @@
+import fs from 'fs';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_ROOT = '/tmp/nanocrab-skill-versions-test';
+
+vi.mock('./config.js', () => ({
+  CONTAINER_SKILLS_DIR: '/tmp/nanocrab-skill-versions-test/container/skills',
+  STORE_DIR: '/tmp/nanocrab-skill-versions-test/store',
+}));
+
+import {
+  getSkillInstallState,
+  getSkillVersionDiff,
+  listSkillVersions,
+  recordSkillVersion,
+  rollbackSkillVersion,
+} from './skill-versions.js';
+
+function writeSkill(skillPath: string, content: string): void {
+  const dir = path.join(TEST_ROOT, 'container', 'skills', skillPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), content);
+}
+
+describe('skill version history', () => {
+  beforeEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it('records installed skill content and reports install state', () => {
+    writeSkill('battle-reports', '# Battle Reports\n\nv1\n');
+
+    const version = recordSkillVersion({
+      skillPath: 'battle-reports',
+      actor: 'admin',
+      action: 'install',
+    });
+
+    expect(version).toMatchObject({
+      skillPath: 'battle-reports',
+      version: 1,
+      actor: 'admin',
+      action: 'install',
+    });
+    expect(listSkillVersions('battle-reports')).toHaveLength(1);
+    expect(getSkillInstallState('battle-reports')).toMatchObject({
+      status: 'installed',
+      currentVersion: 1,
+      latestVersion: 1,
+    });
+  });
+
+  it('diffs and rolls back to a previous version', () => {
+    writeSkill('battle-reports', '# Battle Reports\n\nv1\n');
+    recordSkillVersion({
+      skillPath: 'battle-reports',
+      actor: 'admin',
+      action: 'install',
+    });
+    writeSkill('battle-reports', '# Battle Reports\n\nv2\n');
+    recordSkillVersion({
+      skillPath: 'battle-reports',
+      actor: 'admin',
+      action: 'update',
+    });
+
+    expect(getSkillVersionDiff('battle-reports', 1, 2)).toContain('-v1');
+
+    const rolledBack = rollbackSkillVersion({
+      skillPath: 'battle-reports',
+      version: 1,
+      actor: 'admin',
+    });
+
+    expect(rolledBack.action).toBe('rollback');
+    expect(
+      fs.readFileSync(
+        path.join(
+          TEST_ROOT,
+          'container',
+          'skills',
+          'battle-reports',
+          'SKILL.md',
+        ),
+        'utf-8',
+      ),
+    ).toContain('v1');
+    expect(
+      listSkillVersions('battle-reports').map((entry) => entry.version),
+    ).toEqual([3, 2, 1]);
+  });
+
+  it('marks installed skills modified when content drifts from latest history', () => {
+    writeSkill('battle-reports', '# Battle Reports\n\nv1\n');
+    recordSkillVersion({
+      skillPath: 'battle-reports',
+      actor: 'admin',
+      action: 'install',
+    });
+    writeSkill('battle-reports', '# Battle Reports\n\nmanual edit\n');
+
+    expect(getSkillInstallState('battle-reports')).toMatchObject({
+      status: 'modified',
+      currentVersion: null,
+      latestVersion: 1,
+    });
+  });
+
+  it('rejects unsafe skill names before reading or writing history', () => {
+    expect(() => listSkillVersions('../outside')).toThrow('Invalid skill name');
+    expect(() =>
+      rollbackSkillVersion({
+        skillPath: '../outside',
+        version: 1,
+        actor: 'admin',
+      }),
+    ).toThrow('Invalid skill name');
+  });
+});

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -1,0 +1,274 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { CONTAINER_SKILLS_DIR, STORE_DIR } from './config.js';
+
+export type SkillVersionAction =
+  | 'install'
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'rollback';
+
+export type SkillInstallStatus =
+  | 'installed'
+  | 'modified'
+  | 'missing'
+  | 'untracked';
+
+export interface SkillVersionEntry {
+  id: string;
+  skillPath: string;
+  version: number;
+  action: SkillVersionAction;
+  actor: string;
+  timestamp: string;
+  sha256: string;
+  bytes: number;
+  note?: string;
+  restoredFromVersion?: number;
+  contentPath: string;
+}
+
+export interface SkillInstallState {
+  status: SkillInstallStatus;
+  skillPath: string;
+  exists: boolean;
+  currentSha256: string | null;
+  currentVersion: number | null;
+  latestVersion: number | null;
+  latestSha256: string | null;
+  updatedAt: string | null;
+}
+
+export interface RecordSkillVersionInput {
+  skillPath: string;
+  actor: string;
+  action: SkillVersionAction;
+  content?: string;
+  note?: string;
+  restoredFromVersion?: number;
+}
+
+export interface RollbackSkillVersionInput {
+  skillPath: string;
+  version: number;
+  actor: string;
+}
+
+const SKILL_VERSIONS_DIR = path.join(STORE_DIR, 'skill-versions');
+
+function assertSafeSkillPath(skillPath: string): string {
+  if (!/^[a-z0-9-]+$/.test(skillPath)) {
+    throw new Error('Invalid skill name');
+  }
+  return skillPath;
+}
+
+function skillDir(skillPath: string): string {
+  return path.join(CONTAINER_SKILLS_DIR, assertSafeSkillPath(skillPath));
+}
+
+function installedSkillMdPath(skillPath: string): string {
+  return path.join(skillDir(skillPath), 'SKILL.md');
+}
+
+function historyDir(skillPath: string): string {
+  return path.join(SKILL_VERSIONS_DIR, assertSafeSkillPath(skillPath));
+}
+
+function metadataPath(skillPath: string): string {
+  return path.join(historyDir(skillPath), 'metadata.json');
+}
+
+function versionContentPath(skillPath: string, version: number): string {
+  return path.join(
+    historyDir(skillPath),
+    `v${String(version).padStart(4, '0')}-SKILL.md`,
+  );
+}
+
+function sha256(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function readInstalledContent(skillPath: string): string | undefined {
+  const file = installedSkillMdPath(skillPath);
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : undefined;
+}
+
+function readMetadata(skillPath: string): SkillVersionEntry[] {
+  assertSafeSkillPath(skillPath);
+  try {
+    const entries = JSON.parse(
+      fs.readFileSync(metadataPath(skillPath), 'utf-8'),
+    ) as SkillVersionEntry[];
+    return entries.filter(
+      (entry) =>
+        entry.skillPath === skillPath &&
+        Number.isInteger(entry.version) &&
+        entry.version > 0,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeMetadata(skillPath: string, entries: SkillVersionEntry[]): void {
+  const dir = historyDir(skillPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    metadataPath(skillPath),
+    `${JSON.stringify(entries, null, 2)}\n`,
+  );
+}
+
+function nextVersion(entries: SkillVersionEntry[]): number {
+  return entries.reduce((max, entry) => Math.max(max, entry.version), 0) + 1;
+}
+
+export function listSkillVersions(skillPath: string): SkillVersionEntry[] {
+  return readMetadata(skillPath).sort((a, b) => b.version - a.version);
+}
+
+export function getSkillInstallState(skillPath: string): SkillInstallState {
+  assertSafeSkillPath(skillPath);
+  const content = readInstalledContent(skillPath);
+  const versions = listSkillVersions(skillPath);
+  const latest = versions[0];
+  const currentSha = content === undefined ? null : sha256(content);
+  const currentVersion =
+    currentSha === null
+      ? null
+      : (versions.find((entry) => entry.sha256 === currentSha)?.version ??
+        null);
+
+  let status: SkillInstallStatus = 'missing';
+  if (content !== undefined && versions.length === 0) status = 'untracked';
+  else if (content !== undefined && latest?.sha256 === currentSha) {
+    status = 'installed';
+  } else if (content !== undefined) status = 'modified';
+
+  return {
+    status,
+    skillPath,
+    exists: content !== undefined,
+    currentSha256: currentSha,
+    currentVersion,
+    latestVersion: latest?.version ?? null,
+    latestSha256: latest?.sha256 ?? null,
+    updatedAt: latest?.timestamp ?? null,
+  };
+}
+
+export function recordSkillVersion(
+  input: RecordSkillVersionInput,
+): SkillVersionEntry {
+  const skillPath = assertSafeSkillPath(input.skillPath);
+  const content = input.content ?? readInstalledContent(skillPath);
+  if (content === undefined) {
+    throw new Error(`Skill not installed: ${skillPath}`);
+  }
+
+  const entries = readMetadata(skillPath);
+  const version = nextVersion(entries);
+  const contentPath = versionContentPath(skillPath, version);
+  const entry: SkillVersionEntry = {
+    id: `skill-version-${Date.now()}-${crypto.randomUUID()}`,
+    skillPath,
+    version,
+    action: input.action,
+    actor: input.actor,
+    timestamp: new Date().toISOString(),
+    sha256: sha256(content),
+    bytes: Buffer.byteLength(content, 'utf-8'),
+    note: input.note,
+    restoredFromVersion: input.restoredFromVersion,
+    contentPath,
+  };
+
+  fs.mkdirSync(historyDir(skillPath), { recursive: true });
+  fs.writeFileSync(contentPath, content);
+  writeMetadata(skillPath, [...entries, entry]);
+  return entry;
+}
+
+function getSkillVersion(
+  skillPath: string,
+  version: number,
+): SkillVersionEntry {
+  const entry = readMetadata(skillPath).find(
+    (item) => item.version === version,
+  );
+  if (!entry)
+    throw new Error(`Skill version not found: ${skillPath}@${version}`);
+  return entry;
+}
+
+function readVersionContent(skillPath: string, version: number): string {
+  const entry = getSkillVersion(skillPath, version);
+  return fs.readFileSync(entry.contentPath, 'utf-8');
+}
+
+function diffLines(
+  fromLabel: string,
+  fromContent: string,
+  toLabel: string,
+  toContent: string,
+): string {
+  const from = fromContent.split(/\r?\n/);
+  const to = toContent.split(/\r?\n/);
+  const lines = [`--- ${fromLabel}`, `+++ ${toLabel}`];
+  const max = Math.max(from.length, to.length);
+  for (let i = 0; i < max; i += 1) {
+    if (from[i] === to[i]) {
+      if (from[i] !== undefined) lines.push(` ${from[i]}`);
+      continue;
+    }
+    if (from[i] !== undefined) lines.push(`-${from[i]}`);
+    if (to[i] !== undefined) lines.push(`+${to[i]}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function getSkillVersionDiff(
+  skillPath: string,
+  fromVersion: number,
+  toVersion?: number,
+): string {
+  assertSafeSkillPath(skillPath);
+  const fromContent = readVersionContent(skillPath, fromVersion);
+  const toContent =
+    toVersion === undefined
+      ? (readInstalledContent(skillPath) ?? '')
+      : readVersionContent(skillPath, toVersion);
+  const toLabel =
+    toVersion === undefined
+      ? `installed/${skillPath}/SKILL.md`
+      : `v${toVersion}/${skillPath}/SKILL.md`;
+  return diffLines(
+    `v${fromVersion}/${skillPath}/SKILL.md`,
+    fromContent,
+    toLabel,
+    toContent,
+  );
+}
+
+export function rollbackSkillVersion(
+  input: RollbackSkillVersionInput,
+): SkillVersionEntry {
+  const skillPath = assertSafeSkillPath(input.skillPath);
+  const content = readVersionContent(skillPath, input.version);
+  const file = installedSkillMdPath(skillPath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return recordSkillVersion({
+    skillPath,
+    actor: input.actor,
+    action: 'rollback',
+    restoredFromVersion: input.version,
+    note: `Restored version ${input.version}`,
+    content,
+  });
+}


### PR DESCRIPTION
Fixes #23

## Summary
- add a skill version-history service with immutable SKILL.md snapshots, install-state detection, diff review, and rollback
- record versions from Skill Factory approvals plus direct dashboard create/edit/delete flows
- expose admin API endpoints and Skills page history/diff/rollback controls with mock-mode sample data
- update README and roadmap notes

## Verification
- rtk mise exec node@22 -- npx vitest run src/skill-versions.test.ts src/skill-factory.test.ts src/skill-registry.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- rtk mise exec node@22 -- npm run format:check
- git diff --check
- mock admin browser check: Skills page shows install-state badges, History panel, version rows, Diff, Rollback, and diff preview text