### PR TITLE
Add inference health dashboard summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ when needed, which is the normal VPS/Linux container path.
 - **Settings -> Provider Profiles** chooses provider/model/tool policy for chat, coding, automations, memory, journal, skill factory, reports, documents, and vision.
 - **Groups -> Provider** overrides the provider per group.
 - **Integrations -> AI Providers** enables/disables API-key providers.
+- **Monitoring -> Inference Health** shows local vs remote provider readiness, stale probes, average latency, capability tags, and manual re-probe controls.
 
 Settings can close active agent sessions while switching providers. Main-group
 persistent containers restart automatically and new containers pick up the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -319,6 +319,6 @@ These rules are non-negotiable:
    - DONE: Provider/model selectors in Scheduled Tasks UI (creation + edit forms)
    - DONE: Model selector in GitHub coding issue picker
    - DONE: Persistent probe history with dashboard API endpoint
-   - DONE: Periodic probe scheduler (5-min interval) with health dashboard display in Monitoring page
+   - DONE: Periodic probe scheduler (5-min interval) with local/remote inference readiness, stale probes, average latency, capability tags, and health dashboard display in Monitoring page
    - DONE: `POST /providers/probe-all` for manual re-probe from dashboard
    - DONE: 9 tests for probe scheduler (health data, version tracking, failure handling, scheduler lifecycle)

--- a/src/admin/mock-data.ts
+++ b/src/admin/mock-data.ts
@@ -1544,67 +1544,111 @@ function routeJson(pathname: string, req: Request): JsonValue | undefined {
     };
   }
   if (pathname === '/providers/health') {
+    const entries = [
+      {
+        profileId: 'default_chat',
+        provider: 'openrouter',
+        model: 'openrouter/auto',
+        purpose: 'Chat',
+        location: 'remote',
+        ok: true,
+        lastProbeAt: new Date(Date.now() - 60000).toISOString(),
+        latencyMs: 420,
+        capabilities: ['tools', 'json', 'stream', 'vision'],
+      },
+      {
+        profileId: 'default_coding',
+        provider: 'codex',
+        model: 'gpt-5.4',
+        purpose: 'Coding',
+        location: 'remote',
+        ok: true,
+        lastProbeAt: new Date(Date.now() - 120000).toISOString(),
+        latencyMs: 780,
+        capabilities: ['tools', 'json', 'stream', 'vision'],
+      },
+      {
+        profileId: 'default_automation',
+        provider: 'openrouter',
+        model: 'openrouter/auto',
+        purpose: 'Automations',
+        location: 'remote',
+        ok: false,
+        lastProbeAt: new Date(Date.now() - 300000).toISOString(),
+        latencyMs: 1260,
+        errorMessage: 'Rate limit exceeded',
+        capabilities: ['tools', 'json', 'stream', 'vision'],
+      },
+      {
+        profileId: 'default_memory',
+        provider: 'ollama',
+        model: 'gemma4:e2b',
+        purpose: 'Memory',
+        location: 'local',
+        ok: true,
+        lastProbeAt: new Date(Date.now() - 3600000).toISOString(),
+        latencyMs: 96,
+        capabilities: ['json', 'stream'],
+      },
+      {
+        profileId: 'default_journal',
+        provider: 'gemini',
+        model: 'gemini-2.5-flash',
+        purpose: 'Journal',
+        location: 'remote',
+        ok: true,
+        lastProbeAt: new Date(Date.now() - 7200000).toISOString(),
+        latencyMs: 510,
+        capabilities: ['json'],
+      },
+      {
+        profileId: 'default_report',
+        provider: 'claude',
+        model: 'claude-sonnet-4-6',
+        purpose: 'Reports',
+        location: 'remote',
+        ok: false,
+        lastProbeAt: new Date(Date.now() - 1800000).toISOString(),
+        latencyMs: 2100,
+        errorMessage:
+          'API reached max capacity: this model is temporarily unavailable',
+        capabilities: ['tools', 'json', 'stream'],
+      },
+    ].map((entry) => ({
+      ...entry,
+      stale:
+        entry.lastProbeAt &&
+        Date.now() - Date.parse(entry.lastProbeAt) > 15 * 60 * 1000,
+      capabilityFlags: {
+        tools: entry.capabilities.includes('tools'),
+        json: entry.capabilities.includes('json'),
+        stream: entry.capabilities.includes('stream'),
+        vision: entry.capabilities.includes('vision'),
+      },
+    }));
+    const remote = entries.filter((entry) => entry.location === 'remote');
+    const local = entries.filter((entry) => entry.location === 'local');
     return {
       version: 1,
-      entries: [
-        {
-          profileId: 'default_chat',
-          provider: 'openrouter',
-          model: 'openrouter/auto',
-          purpose: 'Chat',
-          ok: true,
-          lastProbeAt: new Date(Date.now() - 60000).toISOString(),
-          capabilities: ['tools', 'json', 'stream', 'vision'],
+      generatedAt: new Date().toISOString(),
+      summary: {
+        total: entries.length,
+        ok: entries.filter((entry) => entry.ok).length,
+        failed: entries.filter((entry) => !entry.ok).length,
+        stale: entries.filter((entry) => entry.stale).length,
+        local: {
+          total: local.length,
+          ok: local.filter((entry) => entry.ok).length,
+          failed: local.filter((entry) => !entry.ok).length,
         },
-        {
-          profileId: 'default_coding',
-          provider: 'codex',
-          model: 'gpt-5.4',
-          purpose: 'Coding',
-          ok: true,
-          lastProbeAt: new Date(Date.now() - 120000).toISOString(),
-          capabilities: ['tools', 'json', 'stream', 'vision'],
+        remote: {
+          total: remote.length,
+          ok: remote.filter((entry) => entry.ok).length,
+          failed: remote.filter((entry) => !entry.ok).length,
         },
-        {
-          profileId: 'default_automation',
-          provider: 'openrouter',
-          model: 'openrouter/auto',
-          purpose: 'Automations',
-          ok: false,
-          lastProbeAt: new Date(Date.now() - 300000).toISOString(),
-          errorMessage: 'Rate limit exceeded',
-          capabilities: ['tools', 'json', 'stream', 'vision'],
-        },
-        {
-          profileId: 'default_memory',
-          provider: 'openrouter',
-          model: 'openrouter/auto',
-          purpose: 'Memory',
-          ok: true,
-          lastProbeAt: new Date(Date.now() - 3600000).toISOString(),
-          capabilities: ['json'],
-        },
-        {
-          profileId: 'default_journal',
-          provider: 'gemini',
-          model: 'gemini-2.5-flash',
-          purpose: 'Journal',
-          ok: true,
-          lastProbeAt: new Date(Date.now() - 7200000).toISOString(),
-          capabilities: ['json'],
-        },
-        {
-          profileId: 'default_report',
-          provider: 'claude',
-          model: 'claude-sonnet-4-6',
-          purpose: 'Reports',
-          ok: false,
-          lastProbeAt: new Date(Date.now() - 1800000).toISOString(),
-          errorMessage:
-            'API reached max capacity: this model is temporarily unavailable',
-          capabilities: ['tools', 'json', 'stream'],
-        },
-      ],
+        averageLatencyMs: 861,
+      },
+      entries,
     };
   }
   if (pathname === '/providers/probe-history') {

--- a/src/admin/public/app.js
+++ b/src/admin/public/app.js
@@ -8320,24 +8320,46 @@ async function renderMonitoring(el) {
         const healthEl = document.getElementById('monitoring-health');
         if (healthEl && health && Array.isArray(health.entries)) {
           const allOk = health.entries.every((e) => e.ok);
+          const summary = health.summary || {};
+          const local = summary.local || {};
+          const remote = summary.remote || {};
           healthEl.innerHTML = `
             <div class="card" style="margin:0;margin-top:16px">
               <div class="card-title" style="display:flex;align-items:center;gap:8px">
-                Provider Health
+                Inference Health
                 <span class="badge ${allOk ? 'badge-success' : 'badge-warning'}" style="font-size:10px">${health.entries.filter((e) => e.ok).length}/${health.entries.length} OK</span>
                 <button class="btn btn-sm btn-ghost" style="margin-left:auto;font-size:11px" onclick="runAllProbes()">Re-probe All</button>
               </div>
+              <div class="grid grid-4" style="margin-bottom:12px">
+                <div style="padding:10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg)">
+                  <div style="font-size:11px;color:var(--text-muted);margin-bottom:3px">Remote Ready</div>
+                  <div style="font-size:18px;font-weight:700;color:var(--text)">${Number(remote.ok || 0)}/${Number(remote.total || 0)}</div>
+                </div>
+                <div style="padding:10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg)">
+                  <div style="font-size:11px;color:var(--text-muted);margin-bottom:3px">Local Ready</div>
+                  <div style="font-size:18px;font-weight:700;color:var(--text)">${Number(local.ok || 0)}/${Number(local.total || 0)}</div>
+                </div>
+                <div style="padding:10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg)">
+                  <div style="font-size:11px;color:var(--text-muted);margin-bottom:3px">Avg Latency</div>
+                  <div style="font-size:18px;font-weight:700;color:var(--text)">${summary.averageLatencyMs == null ? '-' : `${Number(summary.averageLatencyMs)}ms`}</div>
+                </div>
+                <div style="padding:10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg)">
+                  <div style="font-size:11px;color:var(--text-muted);margin-bottom:3px">Stale Probes</div>
+                  <div style="font-size:18px;font-weight:700;color:${Number(summary.stale || 0) > 0 ? 'var(--warning)' : 'var(--text)'}">${Number(summary.stale || 0)}</div>
+                </div>
+              </div>
               <div class="table-wrap"><table>
-                <thead><tr><th>Profile</th><th>Provider</th><th>Model</th><th>Status</th><th>Last Probe</th><th>Capabilities</th></tr></thead>
+                <thead><tr><th>Profile</th><th>Provider</th><th>Model</th><th>Status</th><th>Last Probe</th><th>Latency</th><th>Capabilities</th></tr></thead>
                 <tbody>${health.entries
                   .map(
                     (e) => `
                   <tr>
                     <td style="font-weight:500;color:var(--text)">${esc(e.purpose)}</td>
-                    <td><span class="badge badge-accent">${esc(e.provider)}</span></td>
+                    <td><span class="badge ${e.location === 'local' ? 'badge-success' : 'badge-accent'}">${esc(e.location || 'remote')}</span> <span class="badge badge-muted">${esc(e.provider)}</span></td>
                     <td style="font-family:var(--mono);font-size:11px;color:var(--text)">${esc(e.model)}</td>
-                    <td><span class="status-dot ${e.ok ? 'online' : 'offline'}" style="margin-right:4px"></span><span class="badge ${e.ok ? 'badge-success' : 'badge-error'}" style="font-size:10px">${e.ok ? 'Ready' : 'Failed'}</span>${e.errorMessage ? `<div style="font-size:10px;color:var(--error);margin-top:2px">${esc(e.errorMessage)}</div>` : ''}</td>
+                    <td><span class="status-dot ${e.ok ? 'online' : 'offline'}" style="margin-right:4px"></span><span class="badge ${e.ok ? 'badge-success' : 'badge-error'}" style="font-size:10px">${e.ok ? 'Ready' : 'Failed'}</span>${e.stale ? ' <span class="badge badge-warning" style="font-size:9px">stale</span>' : ''}${e.errorMessage ? `<div style="font-size:10px;color:var(--error);margin-top:2px">${esc(e.errorMessage)}</div>` : ''}</td>
                     <td style="font-size:11px;color:var(--text-muted)">${e.lastProbeAt ? formatTime(e.lastProbeAt) : '-'}</td>
+                    <td style="font-size:11px;color:var(--text-muted)">${e.latencyMs == null ? '-' : `${Number(e.latencyMs)}ms`}</td>
                     <td>${e.capabilities.length > 0 ? e.capabilities.map((c) => `<span class="badge badge-info" style="font-size:9px">${esc(c)}</span>`).join(' ') : '<span class="badge badge-muted" style="font-size:9px">unprobed</span>'}</td>
                   </tr>`,
                   )

--- a/src/probe-scheduler.test.ts
+++ b/src/probe-scheduler.test.ts
@@ -45,8 +45,8 @@ vi.mock('./provider-router.js', () => {
     },
     {
       id: 'default_coding',
-      provider: 'codex',
-      model: 'gpt-5.4',
+      provider: 'ollama',
+      model: 'gemma4:e2b',
       purpose: 'default_coding',
     },
   ];
@@ -60,6 +60,7 @@ vi.mock('./provider-router.js', () => {
       async () =>
         ({
           ok: true,
+          latencyMs: 120,
           errors: undefined,
           lastProbeAt: new Date().toISOString(),
           capabilities: {
@@ -90,6 +91,7 @@ describe('probe-scheduler', () => {
       async () =>
         ({
           ok: true,
+          latencyMs: 120,
           errors: undefined,
           lastProbeAt: new Date().toISOString(),
           capabilities: {
@@ -130,6 +132,15 @@ describe('probe-scheduler', () => {
     expect(result.entries[0].ok).toBe(true);
     expect(result.entries[1].profileId).toBe('default_coding');
     expect(result.entries[1].ok).toBe(true);
+    expect(result.entries[1].location).toBe('local');
+    expect(result.summary).toMatchObject({
+      total: 2,
+      ok: 2,
+      failed: 0,
+      local: { total: 1, ok: 1, failed: 0 },
+      remote: { total: 1, ok: 1, failed: 0 },
+      averageLatencyMs: 120,
+    });
   });
 
   it('runAllProbes increments version on each run', async () => {
@@ -158,6 +169,7 @@ describe('probe-scheduler', () => {
     const health = mod.getProbeHealth();
     expect(health.version).toBe(1);
     expect(health.entries).toHaveLength(2);
+    expect(health.summary.total).toBe(2);
   });
 
   it('probe health entries include capability tags from probe results', async () => {
@@ -201,5 +213,6 @@ describe('probe-scheduler', () => {
     const health = mod.getProbeHealth();
     expect(health.version).toBe(1);
     expect(Array.isArray(health.entries)).toBe(true);
+    expect(health.summary.total).toBe(2);
   });
 });

--- a/src/probe-scheduler.ts
+++ b/src/probe-scheduler.ts
@@ -16,52 +16,166 @@ export interface ProbeHealthEntry {
   provider: string;
   model: string;
   purpose: string;
+  location: 'local' | 'remote';
   ok: boolean;
   lastProbeAt: string | null;
+  latencyMs?: number;
   errorMessage?: string;
   capabilities: string[];
+  capabilityFlags: {
+    tools: boolean;
+    json: boolean;
+    stream: boolean;
+    vision: boolean;
+  };
+  stale: boolean;
 }
 
 export interface ProbeHealthData {
   entries: ProbeHealthEntry[];
   version: number;
+  generatedAt: string;
+  summary: ProbeHealthSummary;
 }
 
-let healthData: ProbeHealthData = { entries: [], version: 0 };
+export interface ProbeHealthSummary {
+  total: number;
+  ok: number;
+  failed: number;
+  stale: number;
+  local: {
+    total: number;
+    ok: number;
+    failed: number;
+  };
+  remote: {
+    total: number;
+    ok: number;
+    failed: number;
+  };
+  averageLatencyMs: number | null;
+}
+
+const PROBE_STALE_MS = 15 * 60 * 1000;
+
+function emptySummary(): ProbeHealthSummary {
+  return {
+    total: 0,
+    ok: 0,
+    failed: 0,
+    stale: 0,
+    local: { total: 0, ok: 0, failed: 0 },
+    remote: { total: 0, ok: 0, failed: 0 },
+    averageLatencyMs: null,
+  };
+}
+
+let healthData: ProbeHealthData = {
+  entries: [],
+  version: 0,
+  generatedAt: new Date(0).toISOString(),
+  summary: emptySummary(),
+};
+
+function providerLocation(provider: string): 'local' | 'remote' {
+  return provider === 'ollama' ? 'local' : 'remote';
+}
+
+function isStale(timestamp: string | null): boolean {
+  if (!timestamp) return true;
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) return true;
+  return Date.now() - parsed > PROBE_STALE_MS;
+}
+
+function capabilityTags(
+  probe: ReturnType<typeof getStoredProviderProbes>[string] | null,
+): string[] {
+  const caps: string[] = [];
+  if (probe?.capabilities) {
+    if (probe.capabilities.tool_calls) caps.push('tools');
+    if (probe.capabilities.structured_output) caps.push('json');
+    if (probe.capabilities.streaming) caps.push('stream');
+    if (probe.capabilities.vision) caps.push('vision');
+  }
+  return caps;
+}
+
+function capabilityFlags(
+  capabilities: string[],
+): ProbeHealthEntry['capabilityFlags'] {
+  return {
+    tools: capabilities.includes('tools'),
+    json: capabilities.includes('json'),
+    stream: capabilities.includes('stream'),
+    vision: capabilities.includes('vision'),
+  };
+}
+
+function buildSummary(entries: ProbeHealthEntry[]): ProbeHealthSummary {
+  const summary = emptySummary();
+  summary.total = entries.length;
+  summary.ok = entries.filter((entry) => entry.ok).length;
+  summary.failed = summary.total - summary.ok;
+  summary.stale = entries.filter((entry) => entry.stale).length;
+  const latencies = entries
+    .map((entry) => entry.latencyMs)
+    .filter((latency): latency is number => Number.isFinite(latency));
+  summary.averageLatencyMs = latencies.length
+    ? Math.round(
+        latencies.reduce((total, latency) => total + latency, 0) /
+          latencies.length,
+      )
+    : null;
+  for (const location of ['local', 'remote'] as const) {
+    const scoped = entries.filter((entry) => entry.location === location);
+    summary[location].total = scoped.length;
+    summary[location].ok = scoped.filter((entry) => entry.ok).length;
+    summary[location].failed = summary[location].total - summary[location].ok;
+  }
+  return summary;
+}
 
 function collectHealth(): ProbeHealthEntry[] {
   const profiles = loadProviderProfiles();
   const stored = getStoredProviderProbes();
   return profiles.map((profile) => {
     const probe = stored[profile.id] ?? null;
-    const caps: string[] = [];
-    if (probe?.capabilities) {
-      if (probe.capabilities.tool_calls) caps.push('tools');
-      if (probe.capabilities.structured_output) caps.push('json');
-      if (probe.capabilities.streaming) caps.push('stream');
-      if (probe.capabilities.vision) caps.push('vision');
-    }
+    const capabilities = capabilityTags(probe);
+    const lastProbeAt = probe?.lastProbeAt ?? null;
     return {
       profileId: profile.id,
       provider: profile.provider,
       model: profile.model,
       purpose: profile.purpose || profile.id,
+      location: providerLocation(profile.provider),
       ok: probe?.ok ?? false,
-      lastProbeAt: probe?.lastProbeAt ?? null,
+      lastProbeAt,
+      latencyMs: probe?.latencyMs,
       errorMessage: probe?.errors?.[0],
-      capabilities: caps,
+      capabilities,
+      capabilityFlags: capabilityFlags(capabilities),
+      stale: isStale(lastProbeAt),
     };
   });
 }
 
 export function getProbeHealth(): ProbeHealthData {
-  return { entries: healthData.entries, version: healthData.version };
+  return {
+    entries: healthData.entries,
+    version: healthData.version,
+    generatedAt: healthData.generatedAt,
+    summary: healthData.summary,
+  };
 }
 
 export function refreshProbeHealth(): void {
+  const entries = collectHealth();
   healthData = {
-    entries: collectHealth(),
+    entries,
     version: healthData.version + 1,
+    generatedAt: new Date().toISOString(),
+    summary: buildSummary(entries),
   };
 }
 
@@ -72,22 +186,21 @@ export async function runAllProbes(): Promise<ProbeHealthData> {
   for (const profile of profiles) {
     try {
       const probe = await runLiveProviderProbe(profile);
-      const caps: string[] = [];
-      if (probe.capabilities) {
-        if (probe.capabilities.tool_calls) caps.push('tools');
-        if (probe.capabilities.structured_output) caps.push('json');
-        if (probe.capabilities.streaming) caps.push('stream');
-        if (probe.capabilities.vision) caps.push('vision');
-      }
+      const capabilities = capabilityTags(probe);
+      const lastProbeAt = probe.lastProbeAt ?? null;
       entries.push({
         profileId: profile.id,
         provider: profile.provider,
         model: profile.model,
         purpose: profile.purpose || profile.id,
+        location: providerLocation(profile.provider),
         ok: probe.ok ?? false,
-        lastProbeAt: probe.lastProbeAt ?? null,
+        lastProbeAt,
+        latencyMs: probe.latencyMs,
         errorMessage: probe.errors?.[0],
-        capabilities: caps,
+        capabilities,
+        capabilityFlags: capabilityFlags(capabilities),
+        stale: isStale(lastProbeAt),
       });
     } catch (err) {
       logger.error(
@@ -99,15 +212,24 @@ export async function runAllProbes(): Promise<ProbeHealthData> {
         provider: profile.provider,
         model: profile.model,
         purpose: profile.purpose || profile.id,
+        location: providerLocation(profile.provider),
         ok: false,
         lastProbeAt: new Date().toISOString(),
+        latencyMs: undefined,
         errorMessage: err instanceof Error ? err.message : String(err),
         capabilities: [],
+        capabilityFlags: capabilityFlags([]),
+        stale: false,
       });
     }
   }
 
-  healthData = { entries, version: healthData.version + 1 };
+  healthData = {
+    entries,
+    version: healthData.version + 1,
+    generatedAt: new Date().toISOString(),
+    summary: buildSummary(entries),
+  };
   return healthData;
 }
 
@@ -151,5 +273,10 @@ export function stopProbeScheduler(): void {
 
 export function _resetProbeSchedulerForTests(): void {
   stopProbeScheduler();
-  healthData = { entries: [], version: 0 };
+  healthData = {
+    entries: [],
+    version: 0,
+    generatedAt: new Date(0).toISOString(),
+    summary: emptySummary(),
+  };
 }


### PR DESCRIPTION
Fixes #18

## Summary
- enrich provider probe health data with local/remote location, stale status, latency, capability flags, generated timestamp, and fleet summary totals
- update Monitoring to show Inference Health with remote/local readiness, average latency, stale probes, per-profile latency, local/remote badges, and failures
- add realistic mock-mode inference health data for dashboard preview
- update README and roadmap notes

## Verification
- rtk mise exec node@22 -- npx vitest run src/probe-scheduler.test.ts
- rtk mise exec node@22 -- npm run typecheck
- rtk mise exec node@22 -- npm run build
- rtk mise exec node@22 -- npm test
- rtk mise exec node@22 -- npm run format:check
- git diff --check
- mock admin browser check: Monitoring shows remote/local readiness, average latency, stale probes, local Ollama row, remote failures, and latency/capability columns